### PR TITLE
Remove systemC from the testsuite install dependencies

### DIFF
--- a/.github/workflows/install_dependencies_testsuite_macos.sh
+++ b/.github/workflows/install_dependencies_testsuite_macos.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-brew install ccache deja-gnu icarus-verilog systemc
+brew install ccache deja-gnu icarus-verilog

--- a/.github/workflows/install_dependencies_testsuite_ubuntu.sh
+++ b/.github/workflows/install_dependencies_testsuite_ubuntu.sh
@@ -13,7 +13,3 @@ REL=$(lsb_release -rs | tr -d .)
 if [ $REL -ge 1804 ]; then
     apt-get install -y lld
 fi
-
-if [ $REL -ge 1910 ]; then
-    apt-get install -y libsystemc-dev
-fi


### PR DESCRIPTION
These files were copied from the bsc repo, where systemc is needed.

It might be worth not having a local copy of these files at all, and just getting them from the bsc repo.
