### PR TITLE
Expand the CI's trailing whitespace check

### DIFF
--- a/.github/workflows/check_whitespace.sh
+++ b/.github/workflows/check_whitespace.sh
@@ -8,7 +8,15 @@ RESULT=0
 # Check for trailing whitespace
 
 # For now, restrict to Bluespec code
-CMD="git ls-files | egrep '\.(bs|bsv)$' | xargs grep -H -n -e ' $'"
+
+# We should at least look for both trailing space (' ') and tab ('\t').
+# By using '\s' in the grep pattern, we also check for CR ('\r') and
+# LF ('\f').  If we wanted to allow DOS files (that end lines with \r\n)
+# then the grep pattern would need to be '( |\t|\f)\r?$' so that we detect
+# spaces and tabs that are followed by CR (and thus not fully trailing).
+
+ALLOWFILE=${SCRIPTDIR}/allow_whitespace.pats
+CMD="git ls-files | egrep '\.(bs|bsv)$' | xargs grep -H -n -e '\s$'"
 if [ $(eval "$CMD -l -- | wc -l") -ne 0 ]; then
     eval "$CMD --" || true
     echo "Trailing whitespace found!"


### PR DESCRIPTION
to also check for trailing tabs and to also find trailing space or tab
in DOS files where the space/tab is not technically trailing, because
there is a carriage return (\r) at the end of the line -- which is
trivially handled by disallowing DOS files and checking for any
trailing space, including CRs and line feeds (LF).