### PR TITLE
Fix bug with unpacking signed integers

### DIFF
--- a/Libraries/GenC/GenCRepr/GenCRepr.bs
+++ b/Libraries/GenC/GenCRepr/GenCRepr.bs
@@ -158,7 +158,15 @@ instance (Div b 8 n) => GenCRepr (Int b) n where
 
   unpackBytesS = State $ \ x ->
     (Prelude.unpack $ fromByteList $ take (valueOf n) x, drop (valueOf n) x)
-  genCUnpack _ = genCIntUnpack (valueOf n)
+  genCUnpack _ val buf =
+    genCIntUnpack (valueOf n) val buf +++
+    case numCBytes (valueOf n) of
+      Nothing -> ""
+      Just nc ->
+        if nc * 8 == valueOf b then ""
+        else "\n" +++
+          "\t// Signed type does not exactly fit a C integer type, pad with the sign bit\n" +++
+          "\t" +++ val +++ " |= " +++ val +++ " >> " +++ integerToString (valueOf b - 1) +++ " == 0? 0 : -1 << " +++ integerToString (valueOf b) +++ ";"
 
 instance GenCRepr Bool 1 where
   typeName _ = "bool"

--- a/testing/bsc.contrib/GenC/GenCRepr/Test.bs
+++ b/testing/bsc.contrib/GenC/GenCRepr/Test.bs
@@ -38,7 +38,7 @@ struct Thing =
 struct ThingMsg =
   thing :: Thing
   swapXY :: Bool
-  deltaZ :: Int 8
+  deltaZ :: Int 5
 
 actTestThing :: ThingMsg -> Action
 actTestThing tm = do

--- a/testing/bsc.contrib/GenC/GenCRepr/sysTest.out.expected
+++ b/testing/bsc.contrib/GenC/GenCRepr/sysTest.out.expected
@@ -2,7 +2,7 @@ Cons 0x00 Nil
 Cons 0x01 Nil
 Cons 0x02 Nil
 Cons 0x03 Nil
-ThingMsg {thing=Thing {w=[   1,    2]; x=  1; y=  2; z=  4660}; swapXY=False; deltaZ=   8}
+ThingMsg {thing=Thing {w=[   1,    2]; x=  1; y=  2; z=  4660}; swapXY=False; deltaZ=  8}
 Cons 0x01 (Cons 0x02 (Cons 0x01 (Cons 0x02 (Cons 0x12 (Cons 0x34 (Cons 0x00 (Cons 0x08 Nil)))))))
 0x0102010212340008
 Called test_fn 102010212340008
@@ -12,10 +12,10 @@ Packed res: 90a0102123c
 0x090a0102123c
 Cons 0x09 (Cons 0x0a (Cons 0x01 (Cons 0x02 (Cons 0x12 (Cons 0x3c Nil)))))
 Thing {w=[   9,   10]; x=  1; y=  2; z=  4668}
-ThingMsg {thing=Thing {w=[   1,    2]; x=  1; y=  2; z=  4660}; swapXY=True; deltaZ=  -8}
-Cons 0x01 (Cons 0x02 (Cons 0x01 (Cons 0x02 (Cons 0x12 (Cons 0x34 (Cons 0x01 (Cons 0xf8 Nil)))))))
-0x01020102123401f8
-Called test_fn 1020102123401f8
+ThingMsg {thing=Thing {w=[   1,    2]; x=  1; y=  2; z=  4660}; swapXY=True; deltaZ= -8}
+Cons 0x01 (Cons 0x02 (Cons 0x01 (Cons 0x02 (Cons 0x12 (Cons 0x34 (Cons 0x01 (Cons 0x18 Nil)))))))
+0x0102010212340118
+Called test_fn 102010212340118
 Unpacked msg: 1 2 1 2 4660 1 -8
 res: -7 -6 2 1 4652
 Packed res: f9fa0201122c


### PR DESCRIPTION
The generated C code for unpacking integers smaller than the corresponding next-largest C type was always padding with zeros.  This is correct for unsigned integers, but signed ints should instead be sign extended.  