### PR TITLE
Remove CI jobs for deprecated Ubuntu 16.04 environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
       fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -70,7 +70,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -123,12 +123,9 @@ jobs:
           ccache --zero-stats --max-size 500M
           export PATH=/usr/lib/ccache:$PATH
 
-          REL=$(lsb_release -rs | tr -d .)
-          if [ $REL -ge 1804 ]; then
-              export LINKER=lld
-          else
-              export LINKER=gold
-          fi
+          # Use the LLVM linker as the C++ linker
+          # for a moderate build-time speedup over ld.bfd
+          export LINKER=lld
           export LDFLAGS="-Wl,-fuse-ld=$LINKER"
 
           # Always archive logs, even if make fails (and terminates this script
@@ -136,8 +133,7 @@ jobs:
           trap ./archive_logs.sh EXIT
 
           # Use -O0 for significantly faster C++ compiles (which more
-          # than make up for slower simulations), and gold as the C++
-          # linked for a moderate build-time speedup over ld.bfd.
+          # than make up for slower simulations)
           export CXXFLAGS="-O0"
 
           cd ../bsc-testsuite/testsuite

--- a/.github/workflows/install_dependencies_testsuite_ubuntu.sh
+++ b/.github/workflows/install_dependencies_testsuite_ubuntu.sh
@@ -5,11 +5,7 @@ apt-get update
 apt-get install -y \
     ccache \
     build-essential \
+    lld \
     tcsh \
     dejagnu \
     iverilog
-
-REL=$(lsb_release -rs | tr -d .)
-if [ $REL -ge 1804 ]; then
-    apt-get install -y lld
-fi


### PR DESCRIPTION
This environment has been deprecated and will be removed 20 Sept 2021.
See:  https://github.com/actions/virtual-environments/issues/3287