### PR TITLE
Add Verilog files for FPGA/Misc/PTMClock package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,11 @@ rem_build:
 
 # -------------------------
 
-.PHONY: install
-install:
-	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  install
+.PHONY: install clean full_clean
+install clean full_clean:
+	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C Verilog    PREFIX=$(PREFIX)  $@
 
-# -------------------------
-
-clean: rem_inst rem_build
-	-$(MAKE)  -C Libraries  clean
-
-full_clean: rem_inst rem_build
-	-$(MAKE)  -C Libraries  full_clean
+clean full_clean: rem_inst rem_build
 
 # -------------------------

--- a/Verilog/ASSIGN1.v
+++ b/Verilog/ASSIGN1.v
@@ -1,0 +1,5 @@
+module ASSIGN1(IN, OUT);
+   output OUT;
+   input IN;
+   assign OUT = IN;
+endmodule

--- a/Verilog/ClockGater.v
+++ b/Verilog/ClockGater.v
@@ -1,0 +1,43 @@
+
+`ifdef BSV_ASSIGNMENT_DELAY
+`else
+  `define BSV_ASSIGNMENT_DELAY
+`endif
+
+`ifdef BSV_POSITIVE_RESET
+  `define BSV_RESET_VALUE 1'b1
+  `define BSV_RESET_EDGE posedge
+`else
+  `define BSV_RESET_VALUE 1'b0
+  `define BSV_RESET_EDGE negedge
+`endif
+
+
+// Bluespec primitive module which gates a clock
+// To avoid glitches, CLK_GATE_OUT only changes  when CLK_IN is low.
+// CLK_GATE_OUT follows CLK_GATE_IN in the same cycle, but COND is first
+// registered, thus delaying the gate condition by one cycle.
+// In this model, the oscillator CLK_OUT does *not* stop when the CLK_GATE_IN or
+// COND are deasserted.
+module ClockGater(
+		  // ports for the internal register
+		  CLK,
+		  RST,
+                  COND,
+		  // ports for the output clock
+                  CLK_OUT,
+                  CLK_GATE_OUT );
+
+   parameter init = 1 ;
+
+   input  CLK ;
+   input  RST ;
+   input  COND ;
+   output CLK_OUT ;
+   output CLK_GATE_OUT ;
+
+   // BUFG buf_gC(.I(CLK), .O(CLK_OUT));
+   assign CLK_OUT = CLK;
+   //BUFG buf_gG(.I(COND),   .O(CLK_GATE_OUT));
+   assign CLK_GATE_OUT = COND;
+endmodule // GatedClock

--- a/Verilog/Makefile
+++ b/Verilog/Makefile
@@ -1,0 +1,25 @@
+PWD:=$(shell pwd)
+TOP:=$(PWD)/..
+
+INSTALL?=install -c
+
+PREFIX?=$(TOP)/inst
+INSTALLDIR=$(PREFIX)/lib/$(INSTALL_NAME)
+
+INSTALL_NAME = Verilog
+
+# -------------------------
+
+VERI_FILES = \
+	ASSIGN1.v \
+	ClockGater.v \
+
+.PHONY: install
+install:
+	$(INSTALL) -m 755 -d $(INSTALLDIR)
+	$(INSTALL) -m 644 $(VERI_FILES) $(INSTALLDIR)
+
+.PHONY: clean full_clean
+clean full_clean:
+
+# -------------------------


### PR DESCRIPTION
The `PTMClock` package imports two Verilog modules that were still in the BSC repo and had accidentally not been migrated here.  (They were removed from the BSC repo in B-Lang-org/bsc#388.)

This repo had not yet been installing any Verilog files, and I had to add a mechanism for storing and installing them. The current structure of this repo mirrors what the BSC repo does, where the library sources are in one (possibly interdependent) tree and the Verilog is in a separate tree.  I would prefer that this repo be structured by project, keeping the source and Verilog (and docs and scripts and any other files) together.  But for now I've just continued to mirror what the BSC repo does.