### PR TITLE
GitHub CI: Update the OS and action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ on: [ push, pull_request ]
 jobs:
   build-check:
     name: "Check: code cleanliness"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check tabs and whitespace
         shell: bash
         run: ".github/workflows/check_whitespace.sh"
@@ -16,12 +16,12 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download bsc
         shell: bash
@@ -44,11 +44,11 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-11, macos-12, macos-13 ]
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download bsc
         shell: bash
         env:
@@ -70,13 +70,13 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         shell: bash
@@ -98,7 +98,7 @@ jobs:
           cp -r testing/bsc.contrib ../bsc-testsuite/testsuite/
 
       - name: Download bsc-contrib
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.os }} build
       - name: Install bsc-contrib
@@ -108,7 +108,7 @@ jobs:
       # in the key so that a new cache file is generated after every
       # successful build, and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -160,7 +160,7 @@ jobs:
       # Save test logs on failure so we can diagnose
       - name: Archive test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-logs-${{ matrix.os }}
           path: logs.tar.gz
@@ -168,12 +168,12 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-11, macos-12, macos-13 ]
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         shell: bash
@@ -195,7 +195,7 @@ jobs:
           cp -r testing/bsc.contrib ../bsc-testsuite/testsuite/
 
       - name: Download bsc-contrib
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.os }} build
       - name: Install bsc-contrib
@@ -205,7 +205,7 @@ jobs:
       # in the key so that a new cache file is generated after every
       # successful build, and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -252,7 +252,7 @@ jobs:
       # Save test logs on failure so we can diagnose
       - name: Archive test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-logs-${{ matrix.os }}
           path: logs.tar.gz


### PR DESCRIPTION
The CI is broken because it is attempting to use runners (for older OS versions) that are no longer available.