### PR TITLE
Decouple restoring credits from dequeuing an Rx FIFO

### DIFF
--- a/Libraries/GenC/GenCMsg/GenCMsg.bs
+++ b/Libraries/GenC/GenCMsg/GenCMsg.bs
@@ -307,19 +307,25 @@ instance (GenCRepr a gcrBytes, GenAllCDecls a, Bits a bBits) =>
     fifo <- mkSizedFIFOF (valueOf bFIFOSize)
     let credits :: Reg (UInt 8)
         credits = head rxCredits
+    
+    restoreCredits :: FIFOF ()
+    restoreCredits <- mkFIFOF
 
     let fifo_o = Rx {
       first = fifo.first;
-      deq   = do { credits := credits + 1; fifo.deq };
+      deq   = do { restoreCredits.enq (); fifo.deq };
       notEmpty = fifo.notEmpty;
     }
 
-    let ruleName = "handle_rx_" +++ stringOf name
     let rs =
           rules
-            ruleName: when rxTagEq (valueOf i + 1) ==> do
+            ("handle_rx_" +++ stringOf name): when rxTagEq (valueOf i + 1) ==> do
               fifo.enq (unpackBytes rxBody).fst
               deq
+            
+            ("restore_credits_" +++ stringOf name): when True ==> do
+              restoreCredits.deq
+              credits := credits + 1
 
     return (Meta $ Conc fifo_o, rs)
 
@@ -376,10 +382,9 @@ instance (GenCRepr a gcrBytes, GenAllCDecls a, Bits a bBits) =>
     let credits :: Reg (UInt 8)
         credits = head txCredits
 
-    let ruleName = "handle_tx_" +++ stringOf name
     let rs =
           rules
-            ruleName: when credits > 0 ==> do
+            ("handle_tx_" +++ stringOf name): when credits > 0 ==> do
               credits := credits - 1
               enq (fromInteger $ valueOf i + 1) $ packBytes fifo.first
               fifo.deq

--- a/Libraries/GenC/GenCMsg/GenCMsg.bs
+++ b/Libraries/GenC/GenCMsg/GenCMsg.bs
@@ -307,7 +307,7 @@ instance (GenCRepr a gcrBytes, GenAllCDecls a, Bits a bBits) =>
     fifo <- mkSizedFIFOF (valueOf bFIFOSize)
     let credits :: Reg (UInt 8)
         credits = head rxCredits
-    
+
     restoreCredits :: FIFOF ()
     restoreCredits <- mkFIFOF
 
@@ -322,7 +322,7 @@ instance (GenCRepr a gcrBytes, GenAllCDecls a, Bits a bBits) =>
             ("handle_rx_" +++ stringOf name): when rxTagEq (valueOf i + 1) ==> do
               fifo.enq (unpackBytes rxBody).fst
               deq
-            
+
             ("restore_credits_" +++ stringOf name): when True ==> do
               restoreCredits.deq
               credits := credits + 1

--- a/Libraries/GenC/GenCMsg/GenCMsg.bs
+++ b/Libraries/GenC/GenCMsg/GenCMsg.bs
@@ -308,6 +308,8 @@ instance (GenCRepr a gcrBytes, GenAllCDecls a, Bits a bBits) =>
     let credits :: Reg (UInt 8)
         credits = head rxCredits
 
+    -- TODO: A more efficient approach would be to make credits a CReg.
+    -- See discussion on https://github.com/B-Lang-org/bsc-contrib/pull/22
     restoreCredits :: FIFOF ()
     restoreCredits <- mkFIFOF
 


### PR DESCRIPTION
Dequeuing from a message FIFO on the device side means that the corresponding `credits` register should be incremented.  This was previously done directly in the `deq` action.  This resulted in mostly harmless, but annoying scheduling conflicts between the `handle_tx_*` rules in the `MsgManager` (which read all the `credits` registers) and any rules in the user's design that make use of a `deq` action (which writes to a `credits` register.)  Since the `handle_tx_` rules are dynamically generated inside the `MsgManager` module, there was no way to specify a scheduling priority and make the warnings go away.  

Instead, use a FIFO to decouple writes to the `credits` registers from the `deq` actions.  