### PR TITLE
Fix GenCRepr to work with changes to derived Generic instance

### DIFF
--- a/Libraries/GenC/GenCRepr/GenCRepr.bs
+++ b/Libraries/GenC/GenCRepr/GenCRepr.bs
@@ -297,7 +297,7 @@ instance (GenCStructBody bodyRepr n, TypeNames ta) =>
     "}")
 
 -- Multi-constructor case, generate a tagged union
-instance (GenCUnionBody tagBytes bodyRepr 0 bodyBytes, TypeNames ta,
+instance (GenCUnionBody tagBytes bodyRepr maxCIdx bodyBytes, TypeNames ta,
           GenCRepr' (Meta (MetaData name pkg ta numCtors) bodyRepr) n1, -- TODO: Why is this context needed?
           Log numCtors tagBits, Div tagBits 8 tagBytes, Add tagBytes bodyBytes n) =>
          GenCRepr' (Meta (MetaData name pkg ta numCtors) bodyRepr) n where
@@ -400,7 +400,7 @@ instance TypeNames () where
 -- Helper type class to handle sum types.
 -- nt = number of tag bytes
 -- a = representation type of contents
--- i = constructor index
+-- i = max constructor index
 -- n = max number of bytes needed to pack any summand
 -- Code generation methods require proxy values for nt and a.
 class GenCUnionBody nt a i n | nt a -> i n where
@@ -418,7 +418,7 @@ class GenCUnionBody nt a i n | nt a -> i n where
 instance (GenCUnionBody tagBytes a i1 n1, GenCUnionBody tagBytes b i2 n2,
           Max n1 n2 n,
           Mul tagBytes 8 tagBits) =>
-         GenCUnionBody tagBytes (Either a b) i1 n where
+         GenCUnionBody tagBytes (Either a b) i2 n where
   genCEnumBody _ _ typeName =
     genCEnumBody (_ :: Bit tagBytes) (_ :: a) typeName +++ ", " +++
     genCEnumBody (_ :: Bit tagBytes) (_ :: b) typeName
@@ -437,7 +437,7 @@ instance (GenCUnionBody tagBytes a i1 n1, GenCUnionBody tagBytes b i2 n2,
 
   unpackUnionBody _ = do
     x <- get
-    if fromByteList (take (valueOf tagBytes) x) == ((fromInteger (valueOf i1)) :: Bit tagBits)
+    if fromByteList (take (valueOf tagBytes) x) <= ((fromInteger (valueOf i1)) :: Bit tagBits)
     then liftM Left $ unpackUnionBody (_ :: Bit tagBytes)
     else liftM Right $ unpackUnionBody (_ :: Bit tagBytes)
   genCUnpackUnionBody _ _ typeName =

--- a/testing/bsc.contrib/GenC/GenCRepr/Calculator.bs
+++ b/testing/bsc.contrib/GenC/GenCRepr/Calculator.bs
@@ -37,6 +37,13 @@ eval Sub x y = x - y
 eval Mul x y = x * y
 eval Div x y = x / y
 
+-- Check that encodings have the expected number of bytes:
+instrSize :: (GenCRepr Instr 6) => ()
+instrSize = ()
+
+resultSize :: (GenCRepr Result 6) => ()
+resultSize = ()
+
 {-# verilog sysCalculator #-}
 sysCalculator :: Module Empty
 sysCalculator = module


### PR DESCRIPTION
See https://github.com/B-Lang-org/bsc/pull/670.

A minor change was needed in the GenCRepr library, for it to work as expected with the changes to derived Generic instances.