### PR TITLE
GitHub CI: Update action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     steps:
@@ -173,6 +174,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     needs: build-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: "Check: code cleanliness"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check tabs and whitespace
         shell: bash
         run: ".github/workflows/check_whitespace.sh"
@@ -21,7 +21,7 @@ jobs:
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download bsc
         uses: B-Lang-org/download-bsc@v1
@@ -36,7 +36,7 @@ jobs:
           tar czf inst.tar.gz inst
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }} build
           path: inst.tar.gz
@@ -48,7 +48,7 @@ jobs:
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download bsc
         uses: B-Lang-org/download-bsc@v1
@@ -63,7 +63,7 @@ jobs:
           tar czf inst.tar.gz inst
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }} build
           path: inst.tar.gz
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         shell: bash
@@ -102,7 +102,7 @@ jobs:
           cp -r testing/bsc.contrib ../bsc-testsuite/testsuite/
 
       - name: Download bsc-contrib
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.os }} build
       - name: Install bsc-contrib
@@ -112,7 +112,7 @@ jobs:
       # in the key so that a new cache file is generated after every
       # successful build, and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -164,7 +164,7 @@ jobs:
       # Save test logs on failure so we can diagnose
       - name: Archive test logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.os }}
           path: logs.tar.gz
@@ -177,7 +177,7 @@ jobs:
     runs-on: ${{ matrix. os }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         shell: bash
@@ -202,7 +202,7 @@ jobs:
           cp -r testing/bsc.contrib ../bsc-testsuite/testsuite/
 
       - name: Download bsc-contrib
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.os }} build
       - name: Install bsc-contrib
@@ -212,7 +212,7 @@ jobs:
       # in the key so that a new cache file is generated after every
       # successful build, and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -259,7 +259,7 @@ jobs:
       # Save test logs on failure so we can diagnose
       - name: Archive test logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.os }}
           path: logs.tar.gz


### PR DESCRIPTION
The checkout and cache versions are updated to newer versions (v4) that use Node 20, because Node 16 is being phased out. The upload- and download-artifact actions are updated to newer versions (v4) that have significant performance improvements.