### PR TITLE
Add a library for generating bit-equivalent SystemVerilog definitions of Bluespec types

### DIFF
--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -6,7 +6,7 @@ BUILD_ORDER = \
 	FPGA \
 	GenC \
 	COBS \
-	VerilogRepr
+	VerilogRepr \
 
 .PHONY: all
 all: install

--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -6,6 +6,7 @@ BUILD_ORDER = \
 	FPGA \
 	GenC \
 	COBS \
+	VerilogRepr
 
 .PHONY: all
 all: install

--- a/Libraries/VerilogRepr/Json.bs
+++ b/Libraries/VerilogRepr/Json.bs
@@ -1,0 +1,112 @@
+-- Author: Lucas Kramer (https://github.com/krame505)
+-- Copyright (c) 2024 MatX, Inc.
+package Json where
+
+import List
+import BuildList
+
+-- This is a generic library for encoding elaboration-time information as JSON.
+-- The schema is defined as types; values of these types can be converted to
+-- Json values as interpreted by the `JsonSchema` typeclass.
+-- See VerilogRepr.bs for an example of how this is used.
+
+-- Abstract syntax representation of JSON values
+data Json
+  = JsonObject (List (String, Json))
+  | JsonArray (List Json)
+  | JsonString String
+  | JsonNumber Integer
+  | JsonBool Bool
+  | JsonNull
+
+showJson :: Json -> String
+showJson =
+  let showJson' :: Integer -> Json -> String
+      showJson' nest (JsonObject fields) = "{" +++
+        -- TODO: escape keys
+        showItems nest
+          (map (\ (key, value) ->
+                  "\"" +++ key +++ "\": " +++ showJson' (nest + 1) value)
+            fields) +++
+        "}"
+      showJson' nest (JsonArray elems) = "[" +++
+        showItems nest (map (showJson' (nest + 1)) elems) +++
+        "]"
+      showJson' _ (JsonString str) = "\"" +++ str +++ "\""  -- TODO: escape
+      showJson' _ (JsonNumber n) = integerToString n
+      showJson' _ (JsonBool b) = if b then "true" else "false"
+      showJson' _ JsonNull = "null"
+
+      showItems :: Integer -> List String -> String
+      showItems _ Nil = ""
+      showItems nest lines =
+        "\n" +++ makeIndent (nest + 1) +++
+        foldr1 (\ line res -> line +++ ",\n" +++ makeIndent (nest + 1) +++ res)
+          lines +++
+        "\n" +++ makeIndent nest
+
+      makeIndent :: Integer -> String
+      makeIndent nest = foldr strConcat "" $ replicate nest "  "
+  in showJson' 0
+
+-- Convert a value of some schema type to a JSON value
+class JsonSchema a where
+  toJson :: a -> Json
+
+instance JsonSchema Integer where
+  toJson n = JsonNumber n
+
+instance JsonSchema String where
+  toJson str = JsonString str
+
+instance JsonSchema Bool where
+  toJson b = JsonBool b
+
+instance (JsonSchema a) => JsonSchema (List (String, a)) where
+  toJson pairs = JsonObject $ map (\ (key, value) -> (key, toJson value)) pairs
+
+instance (JsonSchema a) => JsonSchema (List a) where
+  toJson lst = JsonArray $ map toJson lst
+
+instance (Generic a r, JsonSchema' r) => JsonSchema a where
+  toJson = toJson' ∘ from
+
+class JsonSchema' r where
+  toJson' :: r -> Json
+
+instance (ToJsonObject r) =>
+    JsonSchema' (Meta (MetaData name pkg args 1) r) where
+  toJson' (Meta x) = JsonObject $ toJsonObject x
+
+instance (ToJsonTag r) => JsonSchema' (Meta (MetaData name pkg args n) r) where
+  toJson' (Meta x) = JsonString $ toJsonTag x
+
+class ToJsonObject r where
+  toJsonObject :: r -> List (String, Json)
+
+instance ToJsonObject () where
+  toJsonObject () = nil
+
+instance (ToJsonObject a, ToJsonObject b) => ToJsonObject (a, b) where
+  toJsonObject (a, b) = toJsonObject a `append` toJsonObject b
+
+instance (ToJsonObject a) => ToJsonObject (Meta m a) where
+  toJsonObject (Meta x) = toJsonObject x
+
+instance (JsonSchema a) => ToJsonObject (Meta (MetaField n i) (Conc a)) where
+  toJsonObject (Meta (Conc x)) = lst (stringOf n, toJson x)
+
+instance (JsonSchema a) =>
+    ToJsonObject (Meta (MetaField n i) (Conc (Maybe a))) where
+  toJsonObject (Meta (Conc (Just x))) = lst (stringOf n, toJson x)
+  toJsonObject (Meta (Conc Nothing)) = nil
+
+class ToJsonTag r where
+  toJsonTag :: r -> String
+
+instance (ToJsonTag a, ToJsonTag b) => ToJsonTag (Either a b) where
+  toJsonTag (Left x) = toJsonTag x
+  toJsonTag (Right x) = toJsonTag x
+
+instance ToJsonTag (Meta (MetaConsAnon name i nf) ()) where
+  toJsonTag _ = stringOf name

--- a/Libraries/VerilogRepr/Makefile
+++ b/Libraries/VerilogRepr/Makefile
@@ -1,0 +1,17 @@
+PWD:=$(shell pwd)
+TOP:=$(PWD)/../..
+
+LIBNAME=VerilogRepr
+
+# Requires that TOP and LIBNAME be set
+# Sets BUILDDIR, and BSC and BSCFLAGS if not set
+# and defines the install target
+include ../common.mk
+
+.PHONY: build
+build:
+	$(BSC) -u $(BSCFLAGS) $(notdir $(LIBNAME)).bs
+
+.PHONY: clean full_clean
+clean full_clean:
+

--- a/Libraries/VerilogRepr/VerilogRepr.bs
+++ b/Libraries/VerilogRepr/VerilogRepr.bs
@@ -577,5 +577,5 @@ writeVerilogFile fileName prefix suffix rv = module
   mapM_ (writeVDecl file) decls
   hPutStrLn file suffix
   hClose file
-  -- messageM $ "Verilog type representation file created: " +++ fileName
+  messageM $ "Verilog type representation file created: " +++ fileName
   interface Empty

--- a/Libraries/VerilogRepr/VerilogRepr.bs
+++ b/Libraries/VerilogRepr/VerilogRepr.bs
@@ -6,6 +6,8 @@ import List
 import BuildList
 import qualified Vector
 
+import Json
+
 -- Proxy value used to supply type parameters to type class methods that don't
 -- otherwise use the type parameter. Should never actually be evaluated.
 prx :: a
@@ -29,7 +31,8 @@ dropInitialUnderscore :: List Char -> List Char
 dropInitialUnderscore (Cons c cs) when c == '_' = cs
 dropInitialUnderscore cs = cs
 
--- Convert a type to its Bluespec type expression, or a unique identifier for use in Verilog.
+-- Convert a type to its Bluespec type expression, or a unique identifier for
+-- use in Verilog.
 class TypeId a where
   bsType :: a -> String
   bsTypeP :: a -> String
@@ -58,7 +61,8 @@ instance (TypeId a) => TypeId (Maybe a) where
   verilogTypeId _ = "option_" +++ verilogTypeId (prx :: a)
 
 instance (TypeId a) => TypeId (Vector.Vector n a) where
-  bsType _ = "Vector " +++ integerToString (valueOf n) +++ " " +++ bsTypeP (prx :: a)
+  bsType _ = "Vector " +++ integerToString (valueOf n) +++ " " +++
+    bsTypeP (prx :: a)
   verilogTypeId _ = "array_" +++
     integerToString (valueOf n) +++ "_" +++
     verilogTypeId (prx :: a)
@@ -103,7 +107,8 @@ instance TypeId' (Meta (MetaData name pkg () ncons) a) where
   bsTypeP' _ = stringOf name
   verilogTypeId' _ = toLowerSnakeCase $ stringOf name
 
-instance (TypeId' tyargs) => TypeId' (Meta (MetaData name pkg tyargs ncons) a) where
+instance (TypeId' tyargs) =>
+    TypeId' (Meta (MetaData name pkg tyargs ncons) a) where
   bsType' _ = stringOf name +++ " " +++ bsType' (prx :: tyargs)
   bsTypeP' _ = "(" +++ stringOf name +++ " " +++ bsType' (prx :: tyargs) +++ ")"
   verilogTypeId' _ =
@@ -135,7 +140,7 @@ data VDecl
   | VUnion String (List VField)
   | VEnum String Integer (List String)
   | VTypedef String VType
-  | VLocalParam String Integer
+  | VLocalParam String Integer Integer
   | VComment String
 
 data VField
@@ -147,179 +152,397 @@ data VType
   | VTypeName String
   | VPackedArray Integer VType
 
+-- Write a Verilog AST to a file
+writeVDecl :: Handle -> VDecl -> Module Empty
+writeVDecl file (VStruct name fields) = do
+  hPutStrLn file $ "typedef struct packed {"
+  mapM_ (writeVField file) fields
+  hPutStrLn file $ "} " +++ name +++ ";\n"
+writeVDecl file (VUnion name fields) = do
+  hPutStrLn file $ "typedef union packed {"
+  mapM_ (writeVField file) fields
+  hPutStrLn file $ "} " +++ name +++ ";\n"
+writeVDecl file (VEnum name width tags) = do
+  hPutStrLn file $
+    "typedef enum logic [" +++ integerToString (width - 1) +++ ":0] {"
+  hPutStrLn file $
+    foldr1 (\ a b -> a +++ ",\n" +++ b) $
+    map (\ (tag, i) ->
+      "  " +++ tag +++ " = " +++
+      integerToString width +++ "'d" +++ integerToString i) $
+    zip tags $ upto 0 $ length tags
+  hPutStrLn file $ "} " +++ name +++ ";\n"
+writeVDecl file (VTypedef name ty) = do
+  hPutStrLn file $ "typedef " +++ ppVType ty +++ " " +++ name +++ ";\n"
+writeVDecl file (VLocalParam name size value) = do
+  if value > 2**size - 1
+    then errorM $ "Value " +++ integerToString value +++
+      " does not fit in " +++ integerToString size +++
+      " bits"
+    else return ()
+  hPutStrLn file $ "localparam " +++ name +++ " = " +++
+    integerToString size +++ "'d" +++
+    integerToString value +++ ";"
+writeVDecl file (VComment comment) = hPutStrLn file $ "// " +++ comment
+
+writeVField :: Handle -> VField -> Module Empty
+writeVField file (VField ty name) =
+  hPutStrLn file $ "  " +++ ppVType ty +++ " " +++ name +++ ";"
+
+ppVType :: VType -> String
+ppVType ty = lppVType ty +++ (if rpp == "" then "" else " " +++ rpp)
+  where rpp = rppVType ty
+
+lppVType :: VType -> String
+lppVType VLogic = "logic"
+lppVType VLogicSigned = "logic signed"
+lppVType (VTypeName name) = name
+lppVType (VPackedArray _ ty) = lppVType ty
+
+rppVType :: VType -> String
+rppVType (VPackedArray size ty) =
+  "[" +++ integerToString (size - 1) +++ ":0]" +++ rppVType ty
+rppVType _ = ""
+
+vTypeArraySizes :: VType -> List Integer
+vTypeArraySizes (VPackedArray size ty) = size :> vTypeArraySizes ty
+vTypeArraySizes _ = nil
+
 -- Get the list of names defined by a Verilog declaration.
 vDeclNames :: VDecl -> List String
 vDeclNames (VStruct name _) = lst name
 vDeclNames (VUnion name _) = lst name
 vDeclNames (VEnum name _ tags) = name :> tags
 vDeclNames (VTypedef name _) = lst name
-vDeclNames (VLocalParam name _) = lst name
+vDeclNames (VLocalParam name _ _) = lst name
 vDeclNames (VComment _) = nil
 
-makeLogicArray :: Integer -> VType
-makeLogicArray 0 =
+makeLogicArray :: Integer -> Bool -> VType
+makeLogicArray 0 _ =
   error "Demanded Verilog representation of zero-width type"
-makeLogicArray 1 = VLogic
-makeLogicArray n = VPackedArray n VLogic
+makeLogicArray 1 signed = if signed then VLogicSigned else VLogic
+makeLogicArray n signed = VPackedArray n $
+  if signed then VLogicSigned else VLogic
 
-makeSignedLogicArray :: Integer -> VType
-makeSignedLogicArray 0 =
-  error "Demanded Verilog representation of zero-width type"
-makeSignedLogicArray 1 = VLogicSigned
-makeSignedLogicArray n = VPackedArray n VLogicSigned
+-- Schema for JSON representation of Verilog types generated from Bluespec.
+-- The JSON file we generate consists of an array of encoded TypeInfo objects.
+struct TypeInfo =
+  -- The Bluespec type expression
+  bsType :: String
+  -- The size of the type in bits
+  size :: Integer
+  -- The SystemVerilog base type (e.g. "logic" or "some_struct_t")
+  baseType :: String
+  -- The array sizes of the type, if any (e.g. "logic [1:0][7:0]" would be
+  -- `lst 2 8`)
+  arraySize :: List Integer
+  -- What sort of type this is - primitive, struct, enum, etc.
+  sort :: TypeSort
+  -- Whether this type is signed, if the type is a primitive
+  signed :: Maybe Bool
+  -- The type's fields, if it's a struct
+  fields :: Maybe (List FieldInfo)
+  -- The values of the type's enum tags, if the type is an enum or tagged union
+  enumValues :: Maybe (List (String, Integer))
+  -- The size of the type's tag enum, if the type is a tagged union
+  tagSize :: Maybe Integer
+  -- The size of the type's union, if the type is a tagged union
+  contentSize :: Maybe Integer
+  -- The name of the type's tag enum, if the type is a tagged union
+  tagEnumName :: Maybe String
+  -- The name of the type's union, if the type is a tagged union
+  unionName :: Maybe String
+  -- The type's alternatives that contain data, if the type is a tagged union
+  alts :: Maybe (List TagInfo)
+
+data TypeSort = Primitive | Vector | Struct | Enum | TaggedUnion
+
+struct TagInfo =
+  -- The name of the enum tag
+  tagName :: String
+  -- The name of the union field that this tag corresponds to
+  fieldName :: String
+  -- The name of the SystemVerilog struct containing the content for this tag
+  structName :: String
+  -- The amount of padding in the struct before the content data
+  padSize :: Integer
+  -- The size of the content data in the struct
+  contentSize :: Integer
+  -- The content fields of the struct
+  fields :: List FieldInfo
+
+struct FieldInfo =
+  -- The name of the field
+  name :: String
+  -- The size of the field in bits
+  size :: Integer
+  -- The Bluespec type of the field
+  bsType :: String
+  -- The SystemVerilog type (e.g. "logic" or "some_struct_t")
+  baseType :: String
+  -- The array sizes of the type, if any (e.g. "logic [0:1][0:7]" would be
+  -- `lst 2 8`)
+  arraySize :: List Integer
+
+bsTypeEquals :: String -> TypeInfo -> Bool
+bsTypeEquals bsType info = bsType == info.bsType
 
 -- Monad for rendering types into Verilog declarations.
 -- This is essentially a State monad that tracks:
 --   * A map of instantiated names to the Bluespec package of their definition
 --   * A list of Verilog declarations created so far
+--   * A list of type information structures created so far
 data RenderVerilog a
   = RenderVerilog
-      (List (String, String) -> List VDecl ->
-       (a, List (String, String), List VDecl))
+      (List (String, String) -> List VDecl -> List TypeInfo ->
+       (a, List (String, String), List VDecl, List TypeInfo))
 
 instance Monad RenderVerilog where
-  return x = RenderVerilog $ \ names decls -> (x, names, decls)
-  bind (RenderVerilog f) g = RenderVerilog $ \ names decls ->
-    case f names decls of
-      (x, names', decls') ->
+  return x = RenderVerilog $ \ names decls infos -> (x, names, decls, infos)
+  bind (RenderVerilog f) g = RenderVerilog $ \ names decls infos ->
+    case f names decls infos of
+      (x, names', decls', infos') ->
         case g x of
-          RenderVerilog g' -> g' names' decls'
+          RenderVerilog g' -> g' names' decls' infos'
 
--- Run a RenderVerilog computation, returning the list of Verilog declarations.
-runRenderVerilog :: RenderVerilog () -> List VDecl
-runRenderVerilog (RenderVerilog f) = tpl_3 $ f nil nil
+struct RenderVerilogResult =
+  decls :: List VDecl
+  infos :: List TypeInfo
+
+-- Run a RenderVerilog computation, returning the list of Verilog declarations
+-- and list of TypeInfos.
+runRenderVerilog :: RenderVerilog () -> RenderVerilogResult
+runRenderVerilog (RenderVerilog f) =
+  let (_, _, decls, infos) = f nil nil nil
+  in RenderVerilogResult { decls = decls; infos = infos; }
 
 -- Add a Verilog declaration (from a given a Bluespec package) to the result.
 -- Errors on duplicate declarations.
 emitDecl :: String -> VDecl -> RenderVerilog ()
-emitDecl pkg newDecl = RenderVerilog $ \ names decls ->
+emitDecl pkg newDecl = RenderVerilog $ \ names decls infos ->
   let checkName newName =
         case lookup newName names of
           Just pkg' ->
             error $ "Error: duplicate definitions created for " +++ newName +++
             " (from package " +++ pkg +++ " and " +++ pkg' +++ ")"
           Nothing -> (newName, pkg)
-  in ((), map checkName (vDeclNames newDecl) `append` names, decls <: newDecl)
+  in ((), map checkName (vDeclNames newDecl) `append` names,
+      decls <: newDecl, infos)
 
 emitDecls :: String -> List VDecl -> RenderVerilog ()
 emitDecls pkg = mapM_ (emitDecl pkg)
+
+-- Add a TypeInfo to the result.
+emitTypeInfo :: TypeInfo -> RenderVerilog ()
+emitTypeInfo info = RenderVerilog $ \ names decls infos ->
+  ((), names, decls, info :> infos)
+
+-- Add a TypeInfo to the result, if it has not yet been added.
+emitTypeInfoIfNeeded :: TypeInfo -> RenderVerilog ()
+emitTypeInfoIfNeeded info = RenderVerilog $ \ names decls infos ->
+  if any (bsTypeEquals info.bsType) infos
+  then ((), names, decls, infos)
+  else ((), names, decls, info :> infos)
 
 -- Control flow combinator - emit some declarations only if they a name has not
 -- already been instantiated. Errors if the name conflicts with a type with the
 -- same name but from a different package.
 whenNoDecl :: String -> String -> RenderVerilog () -> RenderVerilog ()
-whenNoDecl name pkg (RenderVerilog f) = RenderVerilog $ \ names decls ->
+whenNoDecl name pkg (RenderVerilog f) = RenderVerilog $ \ names decls infos ->
   case lookup name names of
     Just pkg' ->
       if pkg == pkg'
-      then ((), names, decls)
+      then ((), names, decls, infos)
       else error $ "Name conflict! " +++ name +++ " from package " +++ pkg +++
         " already instantiated from package " +++ pkg'
-    Nothing -> f names decls
+    Nothing -> f names decls infos
 
--- Helper to generate a struct wrapping some type.
-wrapStruct :: (TypeId a, VerilogRepr a) =>
-  a -> String -> RenderVerilog VType
-wrapStruct proxy pkg = do
+-- Helper function for defining verilogType for a type that maps to a logic
+-- (or logic array) type in Verilog.
+-- The arguments are whether the type is signed, and a proxy for the type.
+mkPrimType :: (VerilogRepr a, TypeId a, Bits a n) => a -> RenderVerilog VType
+mkPrimType proxy = do
+  emitTypeInfoIfNeeded $ TypeInfo {
+    bsType = bsType proxy;
+    size = valueOf n;
+    baseType = "logic";
+    arraySize = if valueOf n == 1 then nil else lst $ valueOf n;
+    sort = Primitive;
+    signed = Just False;
+    fields = Nothing;
+    enumValues = Nothing;
+    tagSize = Nothing;
+    contentSize = Nothing;
+    tagEnumName = Nothing;
+    unionName = Nothing;
+    alts = Nothing;
+  }
+  return $ makeLogicArray (valueOf n) False
+
+-- Helper function for defining verilogType for a type that maps to a struct
+-- type in Verilog, that simply wraps the flattened fields determined by
+-- verilogFields.
+-- The arguments are the package name, the base name of the fields, and a proxy
+-- for the type.
+mkStructType :: (VerilogRepr a, TypeId a, Bits a n) =>
+  String -> String -> a -> RenderVerilog VType
+mkStructType pkg base proxy = do
   let structName = verilogTypeId proxy +++ "_t"
   whenNoDecl structName pkg do
-    fields <- verilogFields proxy "value"
+    fieldsAndInfos <- verilogFields (prx :: a) base
+    let (fields, infos) = unzip fieldsAndInfos
     emitDecls pkg $ lst
       (VComment $ bsType proxy)
       (VStruct structName fields)
+    emitTypeInfo $ TypeInfo {
+      bsType = bsType proxy;
+      size = valueOf n;
+      baseType = structName;
+      arraySize = nil;
+      sort = Struct;
+      signed = Nothing;
+      fields = Just infos;
+      enumValues = Nothing;
+      tagSize = Nothing;
+      contentSize = Nothing;
+      tagEnumName = Nothing;
+      unionName = Nothing;
+      alts = Nothing;
+    }
   return $ VTypeName structName
+
+-- Helper function for defining verilogFields for a type that maps to a single
+-- field.
+mkField :: (VerilogRepr a, TypeId a, Bits a n) =>
+  a -> String -> RenderVerilog (List (VField, FieldInfo))
+mkField proxy name = if valueOf n == 0 then return Nil else do
+  ty <- verilogType proxy
+  let disambName =
+        if elem name verilogReservedWords
+        then name +++ "_"
+        else name
+  return $ lst $ (VField ty disambName, FieldInfo {
+    name = disambName;
+    size = valueOf n;
+    bsType = bsType proxy;
+    baseType = lppVType ty;
+    arraySize = vTypeArraySizes ty;
+  })
+
+verilogReservedWords :: List String
+verilogReservedWords = lst
+  -- Possibly incomplete, generated by an LLM:
+  "reg" "struct" "union" "enum" "localparam" "typedef" "packed" "logic" "signed"
+  "enum" "case" "default" "endcase" "if" "else" "begin" "end" "always" "posedge"
+  "negedge" "module" "endmodule" "input" "output" "inout" "wire" "assign" "for"
+  "while" "repeat" "forever" "initial" "function" "endfunction" "task" "endtask"
+  "fork" "join" "disable" "wait" "casez" "casex" "endcase" "default"
 
 class VerilogRepr a where
   -- Get the Verilog type representation of a Bluespec type.
   verilogType :: a -> RenderVerilog VType
 
-  -- Get the Verilog struct fields corresponding to a Bluespec struct/data
-  -- field of this type.
-  verilogFields :: a -> String -> RenderVerilog (List VField)
+  -- Get the flattened Verilog struct fields for this type, when it appears
+  -- directly as the type of a field in a Bluespec struct. The second argument
+  -- is the base name of the field.
+  verilogFields :: a -> String -> RenderVerilog (List (VField, FieldInfo))
 
 instance VerilogRepr Bool where
-  verilogType _ = return VLogic
-  verilogFields _ name = return $ lst $ VField VLogic name
+  verilogType = mkPrimType
+  verilogFields = mkField
 
 instance VerilogRepr (Bit n) where
-  verilogType _ = return $ makeLogicArray $ valueOf n
-  verilogFields _ name = return $
-    if valueOf n == 0 then nil
-    else lst $ VField (makeLogicArray $ valueOf n) name
+  verilogType = mkPrimType
+  verilogFields = mkField
 
 instance VerilogRepr (UInt n) where
-  verilogType _ = return $ makeLogicArray $ valueOf n
-  verilogFields _ name = return $
-    if valueOf n == 0 then nil
-    else lst $ VField (makeLogicArray $ valueOf n) name
+  verilogType = mkPrimType
+  verilogFields = mkField
 
 instance VerilogRepr (Int n) where
-  verilogType _ = return $ makeSignedLogicArray $ valueOf n
-  verilogFields _ name = return $
-    if valueOf n == 0 then nil
-    else lst $ VField (makeSignedLogicArray $ valueOf n) name
+  verilogType proxy = do
+    let typedefName = "int" +++ integerToString (valueOf n) +++ "_t"
+    whenNoDecl typedefName "Prelude" do
+      emitDecls "Prelude" $ lst
+        (VComment $ "Int " +++ integerToString (valueOf n))
+        (VTypedef typedefName $ makeLogicArray (valueOf n) True)
+      emitTypeInfo $ TypeInfo {
+        bsType = bsType proxy;
+        size = valueOf n;
+        baseType = typedefName;
+        arraySize = nil;
+        sort = Primitive;
+        signed = Just True;
+        fields = Nothing;
+        enumValues = Nothing;
+        tagSize = Nothing;
+        contentSize = Nothing;
+        tagEnumName = Nothing;
+        unionName = Nothing;
+        alts = Nothing;
+      }
+    return $ VTypeName typedefName
+  verilogFields = mkField
 
-instance (TypeId a, VerilogRepr a) => VerilogRepr (Maybe a) where
-  verilogType proxy = wrapStruct proxy "Prelude"
-  verilogFields _ name =
-    fmap (Cons $ VField VLogic $ "has_" +++ name) $
-    verilogFields (prx :: a) name
+instance (VerilogRepr a, Bits a n, TypeId a) => VerilogRepr (Maybe a) where
+  verilogType = mkStructType "Prelude" "value"
+  verilogFields _ base = liftM2 append
+    (mkField (prx :: Bool) ("has_" +++ base))
+    (mkField (prx :: a) base)
 
 instance (TypeId a, VerilogRepr a, Bits a nb) =>
     VerilogRepr (Vector.Vector n a) where
-  verilogType _ = do
+  verilogType proxy = do
     itemType <- verilogType (prx :: a)
+    emitTypeInfoIfNeeded $ TypeInfo {
+      bsType = bsType proxy;
+      size = valueOf n * valueOf nb;
+      baseType = lppVType itemType;
+      arraySize = valueOf n :> vTypeArraySizes itemType;
+      sort = Vector;
+      signed = Nothing;
+      fields = Nothing;
+      enumValues = Nothing;
+      tagSize = Nothing;
+      contentSize = Nothing;
+      tagEnumName = Nothing;
+      unionName = Nothing;
+      alts = Nothing;
+    }
     return $ VPackedArray (valueOf n) itemType
-  verilogFields proxy name =
-    if valueOf n == 0 || valueOf nb == 0
-    then return nil
-    else fmap (\ ty -> lst $ VField ty name) $ verilogType proxy
+  verilogFields = mkField
 
 instance VerilogRepr () where
   verilogType _ = error "Demanded Verilog representation of zero-width type"
   verilogFields _ _ = return nil
 
-instance (TupleTypeId (a, b), VerilogTupleRepr (a, b) 0) =>
+instance (VerilogTupleRepr (a, b), Bits (a, b) n, TupleTypeId (a, b)) =>
     VerilogRepr (a, b) where
-  verilogType proxy = do
-    let structName = verilogTypeId proxy +++ "_t"
-    whenNoDecl structName "Prelude" $ do
-      structFields <- verilogTupleFields proxy (prx :: Bit 0) "f"
-      emitDecls "Prelude" $ lst
-        (VComment $ bsTupleType proxy)
-        (VStruct structName structFields)
-    return $ VTypeName structName
-  verilogFields proxy = verilogTupleFields proxy (prx :: Bit 0)
+  verilogType = mkStructType "Prelude" "f"
+  verilogFields proxy = verilogTupleFields proxy 0
 
-class (VerilogTupleRepr :: * -> # -> *) a i where
-  verilogTupleFields :: a -> Bit i -> String -> RenderVerilog (List VField)
+class VerilogTupleRepr a where
+  verilogTupleFields :: a -> Integer -> String ->
+    RenderVerilog (List (VField, FieldInfo))
 
-instance (VerilogRepr a, VerilogTupleRepr b (TAdd i 1)) =>
-    VerilogTupleRepr (a, b) i where
-  verilogTupleFields _ _ name = liftM2 append
-    (verilogFields (prx :: a) $ name +++ integerToString (valueOf i))
-    (verilogTupleFields (prx :: b) (prx :: Bit (TAdd i 1)) name)
+instance (VerilogRepr a, VerilogTupleRepr b) => VerilogTupleRepr (a, b) where
+  verilogTupleFields _ i name = liftM2 append
+    (verilogFields (prx :: a) $ name +++ integerToString i)
+    (verilogTupleFields (prx :: b) (i + 1) name)
 
-instance (VerilogRepr a) => VerilogTupleRepr a i where
-  verilogTupleFields proxy _ name =
-    verilogFields proxy $ name +++ integerToString (valueOf i)
+instance (VerilogRepr a) => VerilogTupleRepr a where
+  verilogTupleFields proxy i name =
+    verilogFields proxy $ name +++ integerToString i
 
 instance (Bits a n, Generic a r, ContentBits r c,
-          VerilogImpl r c, TypeId a) =>
+          VerilogImpl r c, TypeId a, VerilogRepr a) =>
     VerilogRepr a where
   verilogType proxy = do
     let baseName = verilogTypeId proxy
     let structName = baseName +++ "_t"
-    verilogImpl (prx :: r) (prx :: Bit c) (bsType (prx :: a)) baseName
+    verilogImpl (prx :: r) (prx :: NumArg c) (bsType (prx :: a)) baseName
     return $ VTypeName structName
-  verilogFields proxy name =
-    if valueOf n == 0
-    then return nil
-    else do
-      let baseName = verilogTypeId proxy
-      let structName = baseName +++ "_t"
-      verilogImpl (prx :: r) (prx :: Bit c) (bsType (prx :: a)) baseName
-      return $ lst $ VField (VTypeName structName) name
+  verilogFields = mkField
 
 -- Compute the maximum size of a summand's contents from a generic
 -- representation.
@@ -338,7 +561,7 @@ instance (ContentBits a n1, ContentBits b n2, Add n1 n2 n) =>
 -- a is the generic representation type, c is the max payload content size for
 -- any constructor.
 class VerilogImpl a c where
-  verilogImpl :: a -> Bit c -> String -> String -> RenderVerilog ()
+  verilogImpl :: a -> NumArg c -> String -> String -> RenderVerilog ()
 
 -- Pure enum case
 instance (TagNames a) => VerilogImpl (Meta (MetaData name pkg ta nc) a) 0 where
@@ -348,15 +571,32 @@ instance (TagNames a) => VerilogImpl (Meta (MetaData name pkg ta nc) a) 0 where
     -- and want to use the same tag names.
     let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
     let typedefName = baseName +++ "_t"
+    let enumTagNames = tagNames (prx :: a) $ stringOf name
     whenNoDecl enumName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
-      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH") $
-        log2 $ valueOf nc)
-      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name)) $ valueOf nc)
-      (VEnum enumName (log2 $ valueOf nc) $ tagNames (prx :: a) $
-        stringOf name)
-    whenNoDecl typedefName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
-      (VComment bsType)
-      (VTypedef typedefName $ VTypeName enumName)
+      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH")
+        (log2 $ log2 (valueOf nc) + 1) (log2 $ valueOf nc))
+      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name))
+        (log2 $ valueOf nc + 1) $ valueOf nc)
+      (VEnum enumName (log2 $ valueOf nc) enumTagNames)
+    whenNoDecl typedefName (stringOf pkg) do
+      emitDecls (stringOf pkg) $ lst
+        (VComment bsType)
+        (VTypedef typedefName $ VTypeName enumName)
+      emitTypeInfo $ TypeInfo {
+        bsType = bsType;
+        size = log2 $ valueOf nc;
+        baseType = typedefName;
+        arraySize = nil;
+        sort = Enum;
+        signed = Nothing;
+        fields = Nothing;
+        enumValues = Just $ zip enumTagNames $ 0 `upto` (valueOf nc - 1);
+        tagSize = Nothing;
+        contentSize = Nothing;
+        tagEnumName = Nothing;
+        unionName = Nothing;
+        alts = Nothing;
+      }
 
 instance (VerilogImpl' a c) => VerilogImpl a c where
   verilogImpl = verilogImpl'
@@ -369,7 +609,7 @@ instance (VerilogImpl' a c) => VerilogImpl a c where
 -- and when that fails we fall through to VerilogImpl' and attempt to match the
 -- pure struct cases.
 class VerilogImpl' a c where
-  verilogImpl' :: a -> Bit c -> String -> String -> RenderVerilog ()
+  verilogImpl' :: a -> NumArg c -> String -> String -> RenderVerilog ()
 
 -- Pure struct cases
 instance (VerilogFields a) =>
@@ -379,10 +619,26 @@ instance (VerilogFields a) =>
   verilogImpl' _ _ bsType baseName = do
     let structName = baseName +++ "_t"
     whenNoDecl structName (stringOf pkg) do
-      fields <- verilogFields' (prx :: a) True
+      fieldsAndInfos <- verilogFields' (prx :: a) True
+      let (fields, infos) = unzip fieldsAndInfos
       emitDecls (stringOf pkg) $ lst
         (VComment bsType)
         (VStruct structName fields)
+      emitTypeInfo $ TypeInfo {
+        bsType = bsType;
+        size = valueOf c;
+        baseType = structName;
+        arraySize = nil;
+        sort = Struct;
+        signed = Nothing;
+        fields = Just infos;
+        enumValues = Nothing;
+        tagSize = Nothing;
+        contentSize = Nothing;
+        tagEnumName = Nothing;
+        unionName = Nothing;
+        alts = Nothing;
+      }
 
 instance (VerilogFields a) =>
     VerilogImpl'
@@ -391,79 +647,138 @@ instance (VerilogFields a) =>
   verilogImpl' _ _ bsType baseName = do
     let structName = baseName +++ "_t"
     whenNoDecl structName (stringOf pkg) do
-      fields <- verilogFields' (prx :: a) False
+      fieldsAndInfos <- verilogFields' (prx :: a) False
+      let (fields, infos) = unzip fieldsAndInfos
       emitDecls (stringOf pkg) $ lst
         (VComment bsType)
         (VStruct structName fields)
+      emitTypeInfo $ TypeInfo {
+        bsType = bsType;
+        size = valueOf c;
+        baseType = structName;
+        arraySize = nil;
+        sort = Struct;
+        signed = Nothing;
+        fields = Just infos;
+        enumValues = Nothing;
+        tagSize = Nothing;
+        contentSize = Nothing;
+        tagEnumName = Nothing;
+        unionName = Nothing;
+        alts = Nothing;
+      }
 
 -- Tagged union case
 instance (TagNames a, VerilogSummands a) =>
     VerilogImpl' (Meta (MetaData name pkg ta nc) a) c where
   verilogImpl' _ _ bsType baseName = do
     let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
+    let enumTagNames = tagNames (prx :: a) $ stringOf name
     let unionName = baseName +++ "_content_t"
     let structName = baseName +++ "_t"
     whenNoDecl enumName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
-      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH") $
-        log2 $ valueOf nc)
-      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name)) $ valueOf nc)
-      (VEnum enumName (log2 $ valueOf nc) $ tagNames (prx :: a) $
-        stringOf name)
+      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH")
+        (log2 $ log2 (valueOf nc) + 1) (log2 $ valueOf nc))
+      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name))
+        (log2 $ valueOf nc + 1) $ valueOf nc)
+      (VEnum enumName (log2 $ valueOf nc) enumTagNames)
     whenNoDecl structName (stringOf pkg) do
-      fields <- verilogSummands (prx :: a) baseName (stringOf pkg) $ valueOf c
+      fieldsAndInfos <- verilogSummands
+        (prx :: a) (stringOf name) baseName (stringOf pkg) $ valueOf c
+      let (fields, infos) = unzip fieldsAndInfos
       emitDecls (stringOf pkg) $ lst
         (VUnion unionName fields)
         (VComment bsType)
         (VStruct structName $ lst
           (VField (VTypeName enumName) "tag")
           (VField (VTypeName unionName) "content"))
+      emitTypeInfo $ TypeInfo {
+        bsType = bsType;
+        size = log2 (valueOf nc) + valueOf c;
+        baseType = structName;
+        arraySize = nil;
+        sort = TaggedUnion;
+        signed = Nothing;
+        fields = Nothing;
+        enumValues = Just $ zip enumTagNames $ 0 `upto` (valueOf nc - 1);
+        tagSize = Just $ log2 $ valueOf nc;
+        contentSize = Just $ valueOf c;
+        tagEnumName = Just enumName;
+        unionName = Just unionName;
+        alts = Just infos;
+      }
 
 -- Generate the union fields for summands in a tagged union.
 class VerilogSummands a where
-  verilogSummands ::
-    a -> String -> String -> Integer -> RenderVerilog (List VField)
+  -- Takes a proxy value, the name derived from the (possibly polymorphic)
+  -- type, the name derived from the type after monomorphization, the package
+  -- name, and the maximum content size of any summand.
+  verilogSummands :: a -> String -> String -> String -> Integer ->
+      RenderVerilog (List (VField, TagInfo))
 
 instance (VerilogSummands a, VerilogSummands b) =>
     VerilogSummands (Either a b) where
-  verilogSummands _ baseName pkg maxWidth = liftM2 append
-    (verilogSummands (prx :: a) baseName pkg maxWidth)
-    (verilogSummands (prx :: b) baseName pkg maxWidth)
+  verilogSummands _ polyBaseName baseName pkg maxWidth = liftM2 append
+    (verilogSummands (prx :: a) polyBaseName baseName pkg maxWidth)
+    (verilogSummands (prx :: b) polyBaseName baseName pkg maxWidth)
 
 instance (VerilogFields a, ContentBits a n) =>
     VerilogSummands (Meta (MetaConsNamed name i nfields) a) where
-  verilogSummands _ baseName pkg maxWidth = do
+  verilogSummands _ polyBaseName baseName pkg maxWidth = do
     let structName = baseName +++ "_" +++
           toLowerSnakeCase (stringOf name) +++ "_t"
-    fields <- verilogFields' (prx :: a) True
+    fieldsAndInfos <- verilogFields' (prx :: a) True
+    let (fields, infos) = unzip fieldsAndInfos
     if length fields == 0
       then return nil
       else do
         emitDecl pkg $ VStruct structName $
           if valueOf n < maxWidth
-          then VField (makeLogicArray $ maxWidth - valueOf n) "pad" :> fields
+          then VField (makeLogicArray (maxWidth - valueOf n) False) "pad" :>
+            fields
           else fields
-        return $ lst $ VField (VTypeName structName) $ toLowerSnakeCase $
-          stringOf name
+        return $ lst (
+          VField (VTypeName structName) $ toLowerSnakeCase $ stringOf name,
+          TagInfo {
+            tagName = toUpperSnakeCase $ polyBaseName +++ stringOf name;
+            fieldName = toLowerSnakeCase $ stringOf name;
+            structName = structName;
+            padSize = maxWidth - valueOf n;
+            contentSize = valueOf n;
+            fields = infos;
+          })
 
 instance (VerilogFields a, ContentBits a n) =>
     VerilogSummands (Meta (MetaConsAnon name i nfields) a) where
-  verilogSummands _ baseName pkg maxWidth = do
+  verilogSummands _ polyBaseName baseName pkg maxWidth = do
     let structName = baseName +++ "_" +++
           toLowerSnakeCase (stringOf name) +++ "_t"
-    fields <- verilogFields' (prx :: a) False
+    fieldsAndInfos <- verilogFields' (prx :: a) False
+    let (fields, infos) = unzip fieldsAndInfos
     if length fields == 0
       then return nil
       else do
         emitDecl pkg $ VStruct structName $
           if valueOf n < maxWidth
-          then VField (makeLogicArray $ maxWidth - valueOf n) "pad" :> fields
+          then VField (makeLogicArray (maxWidth - valueOf n) False) "pad" :>
+            fields
           else fields
-        return $ lst $ VField (VTypeName structName) $ toLowerSnakeCase $
-          stringOf name
+        return $ lst (
+          VField (VTypeName structName) $ toLowerSnakeCase $ stringOf name,
+          TagInfo {
+            tagName = toUpperSnakeCase $ polyBaseName +++ stringOf name;
+            fieldName = toLowerSnakeCase $ stringOf name;
+            structName = structName;
+            padSize = maxWidth - valueOf n;
+            contentSize = valueOf n;
+            fields = infos;
+          })
 
 -- Compute the Verilog fields for a single summand.
 class VerilogFields a where
-  verilogFields' :: a -> Bool -> RenderVerilog (List VField)
+  -- Takes a proxy value and a Boolean indicating whether the constructor's
+  -- fields are named or anonymous.
+  verilogFields' :: a -> Bool -> RenderVerilog (List (VField, FieldInfo))
 
 instance VerilogFields () where
   verilogFields' _ _ = return nil
@@ -476,22 +791,9 @@ instance (VerilogFields a, VerilogFields b) => VerilogFields (a, b) where
 instance (VerilogRepr a) =>
     VerilogFields (Meta (MetaField name i) (Conc a)) where
   verilogFields' _ named = verilogFields (prx :: a) $
-    let baseName = toLowerSnakeCase $ stringOf name
-    in
-      if not named
-      then "f" +++ integerToString (valueOf i)
-      else if elem baseName verilogReservedWords
-      then baseName +++ "_"
-      else baseName
-
-verilogReservedWords :: List String
-verilogReservedWords = lst
-  -- Possibly incomplete, generated by an LLM:
-  "reg" "struct" "union" "enum" "localparam" "typedef" "packed" "logic" "signed"
-  "enum" "case" "default" "endcase" "if" "else" "begin" "end" "always" "posedge"
-  "negedge" "module" "endmodule" "input" "output" "inout" "wire" "assign" "for"
-  "while" "repeat" "forever" "initial" "function" "endfunction" "task" "endtask"
-  "fork" "join" "disable" "wait" "casez" "casex" "endcase" "default"
+    if not named
+    then "f" +++ integerToString (valueOf i)
+    else toLowerSnakeCase $ stringOf name
 
 -- Compute the enum field names corresponding to a sum type.
 class TagNames a where
@@ -521,61 +823,30 @@ instance (VerilogRepr a, AllVerilogImpls b) => AllVerilogImpls (a, b) where
     verilogType (prx :: a)
     verilogImpls (prx :: b)
 
--- Write a Verilog AST to a file
-writeVDecl :: Handle -> VDecl -> Module Empty
-writeVDecl file (VStruct name fields) = do
-  hPutStrLn file $ "typedef struct packed {"
-  mapM_ (writeVField file) fields
-  hPutStrLn file $ "} " +++ name +++ ";\n"
-writeVDecl file (VUnion name fields) = do
-  hPutStrLn file $ "typedef union packed {"
-  mapM_ (writeVField file) fields
-  hPutStrLn file $ "} " +++ name +++ ";\n"
-writeVDecl file (VEnum name width tags) = do
-  hPutStrLn file $
-    "typedef enum logic [" +++ integerToString (width - 1) +++ ":0] {"
-  hPutStrLn file $
-    foldr1 (\ a b -> a +++ ",\n" +++ b) $
-    map (\ (tag, i) ->
-      "  " +++ tag +++ " = " +++
-      integerToString width +++ "'d" +++ integerToString i) $
-    zip tags $ upto 0 $ length tags
-  hPutStrLn file $ "} " +++ name +++ ";\n"
-writeVDecl file (VTypedef name ty) = do
-  hPutStrLn file $ "typedef " +++ ppVType ty +++ " " +++ name +++ ";\n"
-writeVDecl file (VLocalParam name value) = do
-  hPutStrLn file $ "localparam " +++ name +++ " = " +++
-    integerToString (log2 $ value + 1) +++ "'d" +++
-    integerToString value +++ ";"
-writeVDecl file (VComment comment) = hPutStrLn file $ "// " +++ comment
-
-writeVField :: Handle -> VField -> Module Empty
-writeVField file (VField ty name) =
-  hPutStrLn file $ "  " +++ ppVType ty +++ " " +++ name +++ ";"
-
-ppVType :: VType -> String
-ppVType ty = lppVType ty +++ (if rpp == "" then "" else " " +++ rpp)
-  where rpp = rppVType ty
-
-lppVType :: VType -> String
-lppVType VLogic = "logic"
-lppVType VLogicSigned = "logic signed"
-lppVType (VTypeName name) = name
-lppVType (VPackedArray _ ty) = lppVType ty
-
-rppVType :: VType -> String
-rppVType (VPackedArray size ty) =
-  "[" +++ integerToString (size - 1) +++ ":0]" +++ rppVType ty
-rppVType _ = ""
-
 writeVerilogFile ::
   String -> String -> String -> RenderVerilog () -> Module Empty
-writeVerilogFile fileName prefix suffix rv = module
-  let decls = runRenderVerilog rv
-  file <- openFile fileName WriteMode
-  hPutStrLn file prefix
-  mapM_ (writeVDecl file) decls
-  hPutStrLn file suffix
-  hClose file
-  messageM $ "Verilog type representation file created: " +++ fileName
+writeVerilogFile svFileName prefix suffix rv = module
+  let result = runRenderVerilog rv
+  svFile <- openFile svFileName WriteMode
+  hPutStrLn svFile prefix
+  mapM_ (writeVDecl svFile) result.decls
+  hPutStrLn svFile suffix
+  hClose svFile
+  -- messageM $ "Verilog type representation file created: " +++ svFileName
+  interface Empty
+
+writeVerilogAndJsonFile ::
+  String -> String -> String -> String -> RenderVerilog () -> Module Empty
+writeVerilogAndJsonFile svFileName jsonFileName prefix suffix rv = module
+  let result = runRenderVerilog rv
+  svFile <- openFile svFileName WriteMode
+  hPutStrLn svFile prefix
+  mapM_ (writeVDecl svFile) result.decls
+  hPutStrLn svFile suffix
+  hClose svFile
+  -- messageM $ "Verilog type representation file created: " +++ svFileName
+  jsonFile <- openFile jsonFileName WriteMode
+  hPutStrLn jsonFile $ showJson $ toJson result.infos
+  hClose jsonFile
+  -- messageM $ "Json dump file created: " +++ jsonFileName
   interface Empty

--- a/Libraries/VerilogRepr/VerilogRepr.bs
+++ b/Libraries/VerilogRepr/VerilogRepr.bs
@@ -1,0 +1,539 @@
+-- Author: Lucas Kramer (https://github.com/krame505)
+-- Copyright (c) 2024 MatX, Inc.
+package VerilogRepr where
+
+import List
+import BuildList
+import qualified Vector
+
+-- Proxy value used to supply type parameters to type class methods that don't
+-- otherwise use the type parameter. Should never actually be evaluated.
+prx :: a
+prx = error "Proxy value, should not be evaluated"
+
+toUpperSnakeCase :: String -> String
+toUpperSnakeCase =
+  charListToString ∘
+  dropInitialUnderscore ∘
+  foldr (\ c s -> if isUpper c then '_' :> c :> s else toUpper c :> s) nil ∘
+  stringToCharList
+
+toLowerSnakeCase :: String -> String
+toLowerSnakeCase =
+  charListToString ∘
+  dropInitialUnderscore ∘
+  foldr (\ c s -> if isUpper c then '_' :> toLower c :> s else c :> s) nil ∘
+  stringToCharList
+
+dropInitialUnderscore :: List Char -> List Char
+dropInitialUnderscore (Cons c cs) when c == '_' = cs
+dropInitialUnderscore cs = cs
+
+-- Get a unique string for the Verilog type, for the purpose of naming type
+-- instantations.
+class VerilogTypeId a where
+  verilogTypeId :: a -> String
+
+instance VerilogTypeId Bool where
+  verilogTypeId _ = "bool"
+
+instance VerilogTypeId (Bit n) where
+  verilogTypeId _ = "bit" +++ integerToString (valueOf n)
+
+instance VerilogTypeId (UInt n) where
+  verilogTypeId _ = "uint" +++ integerToString (valueOf n)
+
+instance VerilogTypeId (Int n) where
+  verilogTypeId _ = "int" +++ integerToString (valueOf n)
+
+instance (VerilogTypeId a) => VerilogTypeId (Maybe a) where
+  verilogTypeId _ = "option_" +++ verilogTypeId (prx :: a)
+
+instance (VerilogTypeId a) => VerilogTypeId (Vector.Vector n a) where
+  verilogTypeId _ = "array_" +++
+    integerToString (valueOf n) +++ "_" +++
+    verilogTypeId (prx :: a)
+
+instance VerilogTypeId () where
+  verilogTypeId _ = "unit"
+
+instance (VerilogTupleTypeId (a, b)) => VerilogTypeId (a, b) where
+  verilogTypeId proxy = "tuple_" +++ verilogTupleTypeId proxy
+
+class VerilogTupleTypeId a where
+  verilogTupleTypeId :: a -> String
+
+instance (VerilogTypeId a, VerilogTupleTypeId b) =>
+    VerilogTupleTypeId (a, b) where
+  verilogTupleTypeId _ =
+    verilogTypeId (prx :: a) +++ "_" +++ verilogTupleTypeId (prx :: b)
+
+instance (VerilogTypeId a) => VerilogTupleTypeId a where
+  verilogTupleTypeId = verilogTypeId
+
+instance (Generic a r, VerilogTypeId' r) => VerilogTypeId a where
+  verilogTypeId _ = verilogTypeId' (prx :: r)
+
+-- Compute the unique type identifier using a type's generic representation.
+class VerilogTypeId' a where
+  verilogTypeId' :: a -> String
+
+instance VerilogTypeId' (Meta (MetaData name pkg () ncons) a) where
+  verilogTypeId' _ = toLowerSnakeCase $ stringOf name
+
+instance (VerilogTypeId' tyargs) =>
+    VerilogTypeId' (Meta (MetaData name pkg tyargs ncons) a) where
+  verilogTypeId' _ =
+    toLowerSnakeCase $ stringOf name +++ "_" +++ verilogTypeId' (prx :: tyargs)
+
+instance (VerilogTypeId' a, VerilogTypeId' b) => VerilogTypeId' (a, b) where
+  verilogTypeId' _ =
+    verilogTypeId' (prx :: a) +++ "_" +++ verilogTypeId' (prx :: b)
+
+instance (VerilogTypeId a) => VerilogTypeId' (StarArg a) where
+  verilogTypeId' _ = verilogTypeId (prx :: a)
+
+instance VerilogTypeId' (NumArg i) where
+  verilogTypeId' _ = integerToString $ valueOf i
+
+instance VerilogTypeId' ConArg where
+  verilogTypeId' _ =
+    error "Demanded Verilog type ID of a higher-kinded type argument"
+
+-- AST representation of Verilog type declarations.
+data VDecl
+  = VStruct String (List VField)
+  | VUnion String (List VField)
+  | VEnum String Integer (List String)
+  | VTypedef String VType
+  | VLocalParam String Integer
+
+data VField
+  = VField VType String
+
+data VType
+  = VLogic
+  | VLogicSigned
+  | VTypeName String
+  | VPackedArray Integer VType
+
+-- Get the list of names defined by a Verilog declaration.
+vDeclNames :: VDecl -> List String
+vDeclNames (VStruct name _) = lst name
+vDeclNames (VUnion name _) = lst name
+vDeclNames (VEnum name _ tags) = name :> tags
+vDeclNames (VTypedef name _) = lst name
+vDeclNames (VLocalParam name _) = lst name
+
+makeLogicArray :: Integer -> VType
+makeLogicArray 0 =
+  error "Demanded Verilog representation of zero-width type"
+makeLogicArray 1 = VLogic
+makeLogicArray n = VPackedArray n VLogic
+
+makeSignedLogicArray :: Integer -> VType
+makeSignedLogicArray 0 =
+  error "Demanded Verilog representation of zero-width type"
+makeSignedLogicArray 1 = VLogicSigned
+makeSignedLogicArray n = VPackedArray n VLogicSigned
+
+-- Monad for rendering types into Verilog declarations.
+-- This is essentially a State monad that tracks:
+--   * A map of instantiated names to the Bluespec package of their definition
+--   * A list of Verilog declarations created so far
+data RenderVerilog a
+  = RenderVerilog
+      (List (String, String) -> List VDecl ->
+       (a, List (String, String), List VDecl))
+
+instance Monad RenderVerilog where
+  return x = RenderVerilog $ \ names decls -> (x, names, decls)
+  bind (RenderVerilog f) g = RenderVerilog $ \ names decls ->
+    case f names decls of
+      (x, names', decls') ->
+        case g x of
+          RenderVerilog g' -> g' names' decls'
+
+-- Run a RenderVerilog computation, returning the list of Verilog declarations.
+runRenderVerilog :: RenderVerilog () -> List VDecl
+runRenderVerilog (RenderVerilog f) = tpl_3 $ f nil nil
+
+-- Add a Verilog declaration (from a given a Bluespec package) to the result.
+-- Errors on duplicate declarations.
+emitDecl :: String -> VDecl -> RenderVerilog ()
+emitDecl pkg newDecl = RenderVerilog $ \ names decls ->
+  let checkName newName =
+        case lookup newName names of
+          Just pkg' ->
+            error $ "Error: duplicate definitions created for " +++ newName +++
+            " (from package " +++ pkg +++ " and " +++ pkg' +++ ")"
+          Nothing -> (newName, pkg)
+  in ((), map checkName (vDeclNames newDecl) `append` names, decls <: newDecl)
+
+emitDecls :: String -> List VDecl -> RenderVerilog ()
+emitDecls pkg = mapM_ (emitDecl pkg)
+
+-- Control flow combinator - emit some declarations only if they a name has not
+-- already been instantiated. Errors if the name conflicts with a type with the
+-- same name but from a different package.
+whenNoDecl :: String -> String -> RenderVerilog () -> RenderVerilog ()
+whenNoDecl name pkg (RenderVerilog f) = RenderVerilog $ \ names decls ->
+  case lookup name names of
+    Just pkg' ->
+      if pkg == pkg'
+      then ((), names, decls)
+      else error $ "Name conflict! " +++ name +++ " from package " +++ pkg +++
+        " already instantiated from package " +++ pkg'
+    Nothing -> f names decls
+
+-- Helper to generate a struct wrapping some type.
+wrapStruct :: (VerilogTypeId a, VerilogRepr a) =>
+  a -> String -> RenderVerilog VType
+wrapStruct proxy pkg = do
+  let structName = verilogTypeId proxy +++ "_t"
+  whenNoDecl structName pkg do
+    fields <- verilogFields proxy "value"
+    emitDecl pkg $ VStruct structName fields
+  return $ VTypeName structName
+
+class VerilogRepr a where
+  -- Get the Verilog type representation of a Bluespec type.
+  verilogType :: a -> RenderVerilog VType
+
+  -- Get the Verilog struct fields corresponding to a Bluespec struct/data
+  -- field of this type.
+  verilogFields :: a -> String -> RenderVerilog (List VField)
+
+instance VerilogRepr Bool where
+  verilogType _ = return VLogic
+  verilogFields _ name = return $ lst $ VField VLogic name
+
+instance VerilogRepr (Bit n) where
+  verilogType _ = return $ makeLogicArray $ valueOf n
+  verilogFields _ name = return $
+    if valueOf n == 0 then nil
+    else lst $ VField (makeLogicArray $ valueOf n) name
+
+instance VerilogRepr (UInt n) where
+  verilogType _ = return $ makeLogicArray $ valueOf n
+  verilogFields _ name = return $
+    if valueOf n == 0 then nil
+    else lst $ VField (makeLogicArray $ valueOf n) name
+
+instance VerilogRepr (Int n) where
+  verilogType _ = return $ makeSignedLogicArray $ valueOf n
+  verilogFields _ name = return $
+    if valueOf n == 0 then nil
+    else lst $ VField (makeSignedLogicArray $ valueOf n) name
+
+instance (VerilogTypeId a, VerilogRepr a) => VerilogRepr (Maybe a) where
+  verilogType proxy = wrapStruct proxy "Prelude"
+  verilogFields _ name =
+    fmap (Cons $ VField VLogic $ "has_" +++ name) $
+    verilogFields (prx :: a) name
+
+instance (VerilogTypeId a, VerilogRepr a, Bits a nb) =>
+    VerilogRepr (Vector.Vector n a) where
+  verilogType _ = do
+    itemType <- verilogType (prx :: a)
+    return $ VPackedArray (valueOf n) itemType
+  verilogFields proxy name =
+    if valueOf n == 0 || valueOf nb == 0
+    then return nil
+    else fmap (\ ty -> lst $ VField ty name) $ verilogType proxy
+
+instance VerilogRepr () where
+  verilogType _ = error "Demanded Verilog representation of zero-width type"
+  verilogFields _ _ = return nil
+
+instance (VerilogTupleTypeId (a, b), VerilogTupleRepr (a, b) 0) =>
+    VerilogRepr (a, b) where
+  verilogType proxy = do
+    let structName = verilogTypeId proxy +++ "_t"
+    whenNoDecl structName "Prelude" $ do
+      structFields <- verilogTupleFields proxy (prx :: Bit 0) "f"
+      emitDecl "Prelude" $ VStruct structName structFields
+    return $ VTypeName structName
+  verilogFields proxy = verilogTupleFields proxy (prx :: Bit 0)
+
+class (VerilogTupleRepr :: * -> # -> *) a i where
+  verilogTupleFields :: a -> Bit i -> String -> RenderVerilog (List VField)
+
+instance (VerilogRepr a, VerilogTupleRepr b (TAdd i 1)) =>
+    VerilogTupleRepr (a, b) i where
+  verilogTupleFields _ _ name = liftM2 append
+    (verilogFields (prx :: a) $ name +++ integerToString (valueOf i))
+    (verilogTupleFields (prx :: b) (prx :: Bit (TAdd i 1)) name)
+
+instance (VerilogRepr a) => VerilogTupleRepr a i where
+  verilogTupleFields proxy _ name =
+    verilogFields proxy $ name +++ integerToString (valueOf i)
+
+instance (Bits a n, Generic a r, ContentBits r c,
+          VerilogImpl r c, VerilogTypeId a) =>
+    VerilogRepr a where
+  verilogType proxy = do
+    let baseName = verilogTypeId proxy
+    let structName = baseName +++ "_t"
+    verilogImpl (prx :: r) (prx :: Bit c) baseName
+    return $ VTypeName structName
+  verilogFields proxy name =
+    if valueOf n == 0
+    then return nil
+    else do
+      let baseName = verilogTypeId proxy
+      let structName = baseName +++ "_t"
+      verilogImpl (prx :: r) (prx :: Bit c) baseName
+      return $ lst $ VField (VTypeName structName) name
+
+-- Compute the maximum size of a summand's contents from a generic
+-- representation.
+class ContentBits a n | a -> n where {}
+instance (Bits a n) => ContentBits (Conc a) n where {}
+instance (Bits a n) => ContentBits (ConcPrim a) n where {}
+instance (ContentBits a n) => ContentBits (Meta m a) n where {}
+instance (ContentBits a n1, ContentBits b n2, Max n1 n2 n) =>
+  ContentBits (Either a b) n where {}
+instance ContentBits () 0 where {}
+instance (ContentBits a n1, ContentBits b n2, Add n1 n2 n) =>
+  ContentBits (a, b) n where {}
+
+-- Generate the Verilog enum, struct and union definitions for a generic
+-- representation.
+-- a is the generic representation type, c is the max payload content size for
+-- any constructor.
+class VerilogImpl a c where
+  verilogImpl :: a -> Bit c -> String -> RenderVerilog ()
+
+-- Pure enum case
+instance (TagNames a) => VerilogImpl (Meta (MetaData name pkg ta nc) a) 0 where
+  verilogImpl _ _ baseName = if valueOf nc <= 1 then return () else do
+    -- Generate the same "tag" enum as the tagged-union case and typedef it,
+    -- since there might be other instantiations that are not a pure enum,
+    -- and want to use the same tag names.
+    let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
+    let typedefName = baseName +++ "_t"
+    whenNoDecl enumName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
+      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH") $
+        log2 $ valueOf nc)
+      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name)) $ valueOf nc)
+      (VEnum enumName (log2 $ valueOf nc) $ tagNames (prx :: a) $
+        stringOf name)
+    whenNoDecl typedefName (stringOf pkg) $ emitDecl (stringOf pkg) $
+      VTypedef typedefName $ VTypeName enumName
+
+instance (VerilogImpl' a c) => VerilogImpl a c where
+  verilogImpl = verilogImpl'
+
+-- This needs to be a seperate type class to avoid overlapping instances for
+-- pure enum/pure struct cases.
+-- In theory, a type with one constructor and no fields could match either case
+-- (since there is no way to make the non-pure-enum cases only match nonzero
+-- payload sizes.) Instead, we match the pure enum case first with VerilogImpl,
+-- and when that fails we fall through to VerilogImpl' and attempt to match the
+-- pure struct cases.
+class VerilogImpl' a c where
+  verilogImpl' :: a -> Bit c -> String -> RenderVerilog ()
+
+-- Pure struct cases
+instance (VerilogFields a) =>
+    VerilogImpl'
+      (Meta (MetaData name pkg ta 1)
+        (Meta (MetaConsNamed cname 0 nfields) a)) c where
+  verilogImpl' _ _ baseName = do
+    let structName = baseName +++ "_t"
+    whenNoDecl structName (stringOf pkg) do
+      fields <- verilogFields' (prx :: a) True
+      emitDecl (stringOf pkg) $ VStruct structName fields
+
+instance (VerilogFields a) =>
+    VerilogImpl'
+      (Meta (MetaData name pkg ta 1)
+        (Meta (MetaConsAnon cname 0 nfields) a)) c where
+  verilogImpl' _ _ baseName = do
+    let structName = baseName +++ "_t"
+    whenNoDecl structName (stringOf pkg) do
+      fields <- verilogFields' (prx :: a) False
+      emitDecl (stringOf pkg) $ VStruct structName fields
+
+-- Tagged union case
+instance (TagNames a, VerilogSummands a) =>
+    VerilogImpl' (Meta (MetaData name pkg ta nc) a) c where
+  verilogImpl' _ _ baseName = do
+    let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
+    let unionName = baseName +++ "_content_t"
+    let structName = baseName +++ "_t"
+    whenNoDecl enumName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
+      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH") $
+        log2 $ valueOf nc)
+      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name)) $ valueOf nc)
+      (VEnum enumName (log2 $ valueOf nc) $ tagNames (prx :: a) $
+        stringOf name)
+    whenNoDecl structName (stringOf pkg) do
+      fields <- verilogSummands (prx :: a) baseName (stringOf pkg) $ valueOf c
+      emitDecls (stringOf pkg) $ lst
+        (VUnion unionName fields)
+        (VStruct structName $ lst
+          (VField (VTypeName enumName) "tag")
+          (VField (VTypeName unionName) "content"))
+
+-- Generate the union fields for summands in a tagged union.
+class VerilogSummands a where
+  verilogSummands ::
+    a -> String -> String -> Integer -> RenderVerilog (List VField)
+
+instance (VerilogSummands a, VerilogSummands b) =>
+    VerilogSummands (Either a b) where
+  verilogSummands _ baseName pkg maxWidth = liftM2 append
+    (verilogSummands (prx :: a) baseName pkg maxWidth)
+    (verilogSummands (prx :: b) baseName pkg maxWidth)
+
+instance (VerilogFields a, ContentBits a n) =>
+    VerilogSummands (Meta (MetaConsNamed name i nfields) a) where
+  verilogSummands _ baseName pkg maxWidth = do
+    let structName = baseName +++ "_" +++
+          toLowerSnakeCase (stringOf name) +++ "_t"
+    fields <- verilogFields' (prx :: a) True
+    if length fields == 0
+      then return nil
+      else do
+        emitDecl pkg $ VStruct structName $
+          if valueOf n < maxWidth
+          then VField (makeLogicArray $ maxWidth - valueOf n) "pad" :> fields
+          else fields
+        return $ lst $ VField (VTypeName structName) $ toLowerSnakeCase $
+          stringOf name
+
+instance (VerilogFields a, ContentBits a n) =>
+    VerilogSummands (Meta (MetaConsAnon name i nfields) a) where
+  verilogSummands _ baseName pkg maxWidth = do
+    let structName = baseName +++ "_" +++
+          toLowerSnakeCase (stringOf name) +++ "_t"
+    fields <- verilogFields' (prx :: a) False
+    if length fields == 0
+      then return nil
+      else do
+        emitDecl pkg $ VStruct structName $
+          if valueOf n < maxWidth
+          then VField (makeLogicArray $ maxWidth - valueOf n) "pad" :> fields
+          else fields
+        return $ lst $ VField (VTypeName structName) $ toLowerSnakeCase $
+          stringOf name
+
+-- Compute the Verilog fields for a single summand.
+class VerilogFields a where
+  verilogFields' :: a -> Bool -> RenderVerilog (List VField)
+
+instance VerilogFields () where
+  verilogFields' _ _ = return nil
+
+instance (VerilogFields a, VerilogFields b) => VerilogFields (a, b) where
+  verilogFields' _  named = liftM2 append
+    (verilogFields' (prx :: a) named)
+    (verilogFields' (prx :: b) named)
+
+instance (VerilogRepr a) =>
+    VerilogFields (Meta (MetaField name i) (Conc a)) where
+  verilogFields' _ named = verilogFields (prx :: a) $
+    let baseName = toLowerSnakeCase $ stringOf name
+    in
+      if not named
+      then "f" +++ integerToString (valueOf i)
+      else if elem baseName verilogReservedWords
+      then baseName +++ "_"
+      else baseName
+
+verilogReservedWords :: List String
+verilogReservedWords = lst
+  -- Possibly incomplete, generated by an LLM:
+  "reg" "struct" "union" "enum" "localparam" "typedef" "packed" "logic" "signed"
+  "enum" "case" "default" "endcase" "if" "else" "begin" "end" "always" "posedge"
+  "negedge" "module" "endmodule" "input" "output" "inout" "wire" "assign" "for"
+  "while" "repeat" "forever" "initial" "function" "endfunction" "task" "endtask"
+  "fork" "join" "disable" "wait" "casez" "casex" "endcase" "default"
+
+-- Compute the enum field names corresponding to a sum type.
+class TagNames a where
+  tagNames :: a -> String -> List String
+
+instance TagNames (Meta (MetaConsNamed name i n) a) where
+  tagNames _ baseName = lst $ toUpperSnakeCase $ baseName +++ stringOf name
+
+instance TagNames (Meta (MetaConsAnon name i n) a) where
+  tagNames _ baseName = lst $ toUpperSnakeCase $ baseName +++ stringOf name
+
+instance (TagNames a, TagNames b) => TagNames (Either a b) where
+  tagNames _ baseName =
+    tagNames (prx :: a) baseName `append` tagNames (prx :: b) baseName
+
+-- Utility to generate the Verilog representations for every type in a tuple.
+class AllVerilogImpls a where
+  verilogImpls :: a -> RenderVerilog ()
+
+instance (VerilogRepr a) => AllVerilogImpls a where
+  verilogImpls _ = do
+    verilogType (prx :: a)
+    return ()
+
+instance (VerilogRepr a, AllVerilogImpls b) => AllVerilogImpls (a, b) where
+  verilogImpls _ = do
+    verilogType (prx :: a)
+    verilogImpls (prx :: b)
+
+-- Write a Verilog AST to a file
+writeVDecl :: Handle -> VDecl -> Module Empty
+writeVDecl file (VStruct name fields) = do
+  hPutStrLn file $ "typedef struct packed {"
+  mapM_ (writeVField file) fields
+  hPutStrLn file $ "} " +++ name +++ ";\n"
+writeVDecl file (VUnion name fields) = do
+  hPutStrLn file $ "typedef union packed {"
+  mapM_ (writeVField file) fields
+  hPutStrLn file $ "} " +++ name +++ ";\n"
+writeVDecl file (VEnum name width tags) = do
+  hPutStrLn file $
+    "typedef enum logic [" +++ integerToString (width - 1) +++ ":0] {"
+  hPutStrLn file $
+    foldr1 (\ a b -> a +++ ",\n" +++ b) $
+    map (\ (tag, i) ->
+      "  " +++ tag +++ " = " +++
+      integerToString width +++ "'d" +++ integerToString i) $
+    zip tags $ upto 0 $ length tags
+  hPutStrLn file $ "} " +++ name +++ ";\n"
+writeVDecl file (VTypedef name ty) = do
+  hPutStrLn file $ "typedef " +++ ppVType ty +++ " " +++ name +++ ";\n"
+writeVDecl file (VLocalParam name value) = do
+  hPutStrLn file $ "localparam " +++ name +++ " = " +++
+    integerToString (log2 $ value + 1) +++ "'d" +++
+    integerToString value +++ ";"
+
+writeVField :: Handle -> VField -> Module Empty
+writeVField file (VField ty name) =
+  hPutStrLn file $ "  " +++ ppVType ty +++ " " +++ name +++ ";"
+
+ppVType :: VType -> String
+ppVType ty = lppVType ty +++ (if rpp == "" then "" else " " +++ rpp)
+  where rpp = rppVType ty
+
+lppVType :: VType -> String
+lppVType VLogic = "logic"
+lppVType VLogicSigned = "logic signed"
+lppVType (VTypeName name) = name
+lppVType (VPackedArray _ ty) = lppVType ty
+
+rppVType :: VType -> String
+rppVType (VPackedArray size ty) =
+  "[" +++ integerToString (size - 1) +++ ":0]" +++ rppVType ty
+rppVType _ = ""
+
+writeVerilogFile ::
+  String -> String -> String -> RenderVerilog () -> Module Empty
+writeVerilogFile fileName prefix suffix rv = module
+  let decls = runRenderVerilog rv
+  file <- openFile fileName WriteMode
+  hPutStrLn file prefix
+  mapM_ (writeVDecl file) decls
+  hPutStrLn file suffix
+  hClose file
+  -- messageM $ "Verilog type representation file created: " +++ fileName
+  interface Empty

--- a/Libraries/VerilogRepr/VerilogRepr.bs
+++ b/Libraries/VerilogRepr/VerilogRepr.bs
@@ -29,74 +29,103 @@ dropInitialUnderscore :: List Char -> List Char
 dropInitialUnderscore (Cons c cs) when c == '_' = cs
 dropInitialUnderscore cs = cs
 
--- Get a unique string for the Verilog type, for the purpose of naming type
--- instantations.
-class VerilogTypeId a where
+-- Convert a type to its Bluespec type expression, or a unique identifier for use in Verilog.
+class TypeId a where
+  bsType :: a -> String
+  bsTypeP :: a -> String
+  bsTypeP proxy = "(" +++ bsType proxy +++ ")"
   verilogTypeId :: a -> String
 
-instance VerilogTypeId Bool where
+instance TypeId Bool where
+  bsType _ = "Bool"
+  bsTypeP _ = "Bool"
   verilogTypeId _ = "bool"
 
-instance VerilogTypeId (Bit n) where
+instance TypeId (Bit n) where
+  bsType _ = "Bit " +++ integerToString (valueOf n)
   verilogTypeId _ = "bit" +++ integerToString (valueOf n)
 
-instance VerilogTypeId (UInt n) where
+instance TypeId (UInt n) where
+  bsType _ = "UInt " +++ integerToString (valueOf n)
   verilogTypeId _ = "uint" +++ integerToString (valueOf n)
 
-instance VerilogTypeId (Int n) where
+instance TypeId (Int n) where
+  bsType _ = "Int " +++ integerToString (valueOf n)
   verilogTypeId _ = "int" +++ integerToString (valueOf n)
 
-instance (VerilogTypeId a) => VerilogTypeId (Maybe a) where
+instance (TypeId a) => TypeId (Maybe a) where
+  bsType _ = "Maybe " +++ bsTypeP (prx :: a)
   verilogTypeId _ = "option_" +++ verilogTypeId (prx :: a)
 
-instance (VerilogTypeId a) => VerilogTypeId (Vector.Vector n a) where
+instance (TypeId a) => TypeId (Vector.Vector n a) where
+  bsType _ = "Vector " +++ integerToString (valueOf n) +++ " " +++ bsTypeP (prx :: a)
   verilogTypeId _ = "array_" +++
     integerToString (valueOf n) +++ "_" +++
     verilogTypeId (prx :: a)
 
-instance VerilogTypeId () where
+instance TypeId () where
+  bsType _ = "()"
+  bsTypeP _ = "()"
   verilogTypeId _ = "unit"
 
-instance (VerilogTupleTypeId (a, b)) => VerilogTypeId (a, b) where
+instance (TupleTypeId (a, b)) => TypeId (a, b) where
+  bsType proxy = "(" +++ bsTupleType proxy +++ ")"
+  bsTypeP proxy = "(" +++ bsTupleType proxy +++ ")"
   verilogTypeId proxy = "tuple_" +++ verilogTupleTypeId proxy
 
-class VerilogTupleTypeId a where
+class TupleTypeId a where
+  bsTupleType :: a -> String
   verilogTupleTypeId :: a -> String
 
-instance (VerilogTypeId a, VerilogTupleTypeId b) =>
-    VerilogTupleTypeId (a, b) where
+instance (TypeId a, TupleTypeId b) => TupleTypeId (a, b) where
+  bsTupleType _ = bsType (prx :: a) +++ ", " +++ bsTupleType (prx :: b)
   verilogTupleTypeId _ =
     verilogTypeId (prx :: a) +++ "_" +++ verilogTupleTypeId (prx :: b)
 
-instance (VerilogTypeId a) => VerilogTupleTypeId a where
+instance (TypeId a) => TupleTypeId a where
+  bsTupleType = bsType
   verilogTupleTypeId = verilogTypeId
 
-instance (Generic a r, VerilogTypeId' r) => VerilogTypeId a where
+instance (Generic a r, TypeId' r) => TypeId a where
+  bsType _ = bsType' (prx :: r)
+  bsTypeP _ = bsTypeP' (prx :: r)
   verilogTypeId _ = verilogTypeId' (prx :: r)
 
 -- Compute the unique type identifier using a type's generic representation.
-class VerilogTypeId' a where
+class TypeId' a where
+  bsType' :: a -> String
+  bsTypeP' :: a -> String
+  bsTypeP' proxy = "(" +++ bsType' proxy +++ ")"
   verilogTypeId' :: a -> String
 
-instance VerilogTypeId' (Meta (MetaData name pkg () ncons) a) where
+instance TypeId' (Meta (MetaData name pkg () ncons) a) where
+  bsType' _ = stringOf name
+  bsTypeP' _ = stringOf name
   verilogTypeId' _ = toLowerSnakeCase $ stringOf name
 
-instance (VerilogTypeId' tyargs) =>
-    VerilogTypeId' (Meta (MetaData name pkg tyargs ncons) a) where
+instance (TypeId' tyargs) => TypeId' (Meta (MetaData name pkg tyargs ncons) a) where
+  bsType' _ = stringOf name +++ " " +++ bsType' (prx :: tyargs)
+  bsTypeP' _ = "(" +++ stringOf name +++ " " +++ bsType' (prx :: tyargs) +++ ")"
   verilogTypeId' _ =
-    toLowerSnakeCase $ stringOf name +++ "_" +++ verilogTypeId' (prx :: tyargs)
+    toLowerSnakeCase (stringOf name) +++ "_" +++ verilogTypeId' (prx :: tyargs)
 
-instance (VerilogTypeId' a, VerilogTypeId' b) => VerilogTypeId' (a, b) where
+instance (TypeId' a, TypeId' b) => TypeId' (a, b) where
+  bsType' _ =
+    bsType' (prx :: a) +++ " " +++ bsType' (prx :: b)
   verilogTypeId' _ =
     verilogTypeId' (prx :: a) +++ "_" +++ verilogTypeId' (prx :: b)
 
-instance (VerilogTypeId a) => VerilogTypeId' (StarArg a) where
+instance (TypeId a) => TypeId' (StarArg a) where
+  bsType' _ = bsTypeP (prx :: a)
   verilogTypeId' _ = verilogTypeId (prx :: a)
 
-instance VerilogTypeId' (NumArg i) where
+instance TypeId' (NumArg i) where
+  bsType' _ = integerToString $ valueOf i
   verilogTypeId' _ = integerToString $ valueOf i
 
-instance VerilogTypeId' ConArg where
+instance TypeId' ConArg where
+  bsType' _ =
+    error "Demanded Bluespec type of a higher-kinded type argument"
   verilogTypeId' _ =
     error "Demanded Verilog type ID of a higher-kinded type argument"
 
@@ -107,6 +136,7 @@ data VDecl
   | VEnum String Integer (List String)
   | VTypedef String VType
   | VLocalParam String Integer
+  | VComment String
 
 data VField
   = VField VType String
@@ -124,6 +154,7 @@ vDeclNames (VUnion name _) = lst name
 vDeclNames (VEnum name _ tags) = name :> tags
 vDeclNames (VTypedef name _) = lst name
 vDeclNames (VLocalParam name _) = lst name
+vDeclNames (VComment _) = nil
 
 makeLogicArray :: Integer -> VType
 makeLogicArray 0 =
@@ -187,13 +218,15 @@ whenNoDecl name pkg (RenderVerilog f) = RenderVerilog $ \ names decls ->
     Nothing -> f names decls
 
 -- Helper to generate a struct wrapping some type.
-wrapStruct :: (VerilogTypeId a, VerilogRepr a) =>
+wrapStruct :: (TypeId a, VerilogRepr a) =>
   a -> String -> RenderVerilog VType
 wrapStruct proxy pkg = do
   let structName = verilogTypeId proxy +++ "_t"
   whenNoDecl structName pkg do
     fields <- verilogFields proxy "value"
-    emitDecl pkg $ VStruct structName fields
+    emitDecls pkg $ lst
+      (VComment $ bsType proxy)
+      (VStruct structName fields)
   return $ VTypeName structName
 
 class VerilogRepr a where
@@ -226,13 +259,13 @@ instance VerilogRepr (Int n) where
     if valueOf n == 0 then nil
     else lst $ VField (makeSignedLogicArray $ valueOf n) name
 
-instance (VerilogTypeId a, VerilogRepr a) => VerilogRepr (Maybe a) where
+instance (TypeId a, VerilogRepr a) => VerilogRepr (Maybe a) where
   verilogType proxy = wrapStruct proxy "Prelude"
   verilogFields _ name =
     fmap (Cons $ VField VLogic $ "has_" +++ name) $
     verilogFields (prx :: a) name
 
-instance (VerilogTypeId a, VerilogRepr a, Bits a nb) =>
+instance (TypeId a, VerilogRepr a, Bits a nb) =>
     VerilogRepr (Vector.Vector n a) where
   verilogType _ = do
     itemType <- verilogType (prx :: a)
@@ -246,13 +279,15 @@ instance VerilogRepr () where
   verilogType _ = error "Demanded Verilog representation of zero-width type"
   verilogFields _ _ = return nil
 
-instance (VerilogTupleTypeId (a, b), VerilogTupleRepr (a, b) 0) =>
+instance (TupleTypeId (a, b), VerilogTupleRepr (a, b) 0) =>
     VerilogRepr (a, b) where
   verilogType proxy = do
     let structName = verilogTypeId proxy +++ "_t"
     whenNoDecl structName "Prelude" $ do
       structFields <- verilogTupleFields proxy (prx :: Bit 0) "f"
-      emitDecl "Prelude" $ VStruct structName structFields
+      emitDecls "Prelude" $ lst
+        (VComment $ bsTupleType proxy)
+        (VStruct structName structFields)
     return $ VTypeName structName
   verilogFields proxy = verilogTupleFields proxy (prx :: Bit 0)
 
@@ -270,12 +305,12 @@ instance (VerilogRepr a) => VerilogTupleRepr a i where
     verilogFields proxy $ name +++ integerToString (valueOf i)
 
 instance (Bits a n, Generic a r, ContentBits r c,
-          VerilogImpl r c, VerilogTypeId a) =>
+          VerilogImpl r c, TypeId a) =>
     VerilogRepr a where
   verilogType proxy = do
     let baseName = verilogTypeId proxy
     let structName = baseName +++ "_t"
-    verilogImpl (prx :: r) (prx :: Bit c) baseName
+    verilogImpl (prx :: r) (prx :: Bit c) (bsType (prx :: a)) baseName
     return $ VTypeName structName
   verilogFields proxy name =
     if valueOf n == 0
@@ -283,7 +318,7 @@ instance (Bits a n, Generic a r, ContentBits r c,
     else do
       let baseName = verilogTypeId proxy
       let structName = baseName +++ "_t"
-      verilogImpl (prx :: r) (prx :: Bit c) baseName
+      verilogImpl (prx :: r) (prx :: Bit c) (bsType (prx :: a)) baseName
       return $ lst $ VField (VTypeName structName) name
 
 -- Compute the maximum size of a summand's contents from a generic
@@ -303,11 +338,11 @@ instance (ContentBits a n1, ContentBits b n2, Add n1 n2 n) =>
 -- a is the generic representation type, c is the max payload content size for
 -- any constructor.
 class VerilogImpl a c where
-  verilogImpl :: a -> Bit c -> String -> RenderVerilog ()
+  verilogImpl :: a -> Bit c -> String -> String -> RenderVerilog ()
 
 -- Pure enum case
 instance (TagNames a) => VerilogImpl (Meta (MetaData name pkg ta nc) a) 0 where
-  verilogImpl _ _ baseName = if valueOf nc <= 1 then return () else do
+  verilogImpl _ _ bsType baseName = if valueOf nc <= 1 then return () else do
     -- Generate the same "tag" enum as the tagged-union case and typedef it,
     -- since there might be other instantiations that are not a pure enum,
     -- and want to use the same tag names.
@@ -319,8 +354,9 @@ instance (TagNames a) => VerilogImpl (Meta (MetaData name pkg ta nc) a) 0 where
       (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name)) $ valueOf nc)
       (VEnum enumName (log2 $ valueOf nc) $ tagNames (prx :: a) $
         stringOf name)
-    whenNoDecl typedefName (stringOf pkg) $ emitDecl (stringOf pkg) $
-      VTypedef typedefName $ VTypeName enumName
+    whenNoDecl typedefName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
+      (VComment bsType)
+      (VTypedef typedefName $ VTypeName enumName)
 
 instance (VerilogImpl' a c) => VerilogImpl a c where
   verilogImpl = verilogImpl'
@@ -333,33 +369,37 @@ instance (VerilogImpl' a c) => VerilogImpl a c where
 -- and when that fails we fall through to VerilogImpl' and attempt to match the
 -- pure struct cases.
 class VerilogImpl' a c where
-  verilogImpl' :: a -> Bit c -> String -> RenderVerilog ()
+  verilogImpl' :: a -> Bit c -> String -> String -> RenderVerilog ()
 
 -- Pure struct cases
 instance (VerilogFields a) =>
     VerilogImpl'
       (Meta (MetaData name pkg ta 1)
         (Meta (MetaConsNamed cname 0 nfields) a)) c where
-  verilogImpl' _ _ baseName = do
+  verilogImpl' _ _ bsType baseName = do
     let structName = baseName +++ "_t"
     whenNoDecl structName (stringOf pkg) do
       fields <- verilogFields' (prx :: a) True
-      emitDecl (stringOf pkg) $ VStruct structName fields
+      emitDecls (stringOf pkg) $ lst
+        (VComment bsType)
+        (VStruct structName fields)
 
 instance (VerilogFields a) =>
     VerilogImpl'
       (Meta (MetaData name pkg ta 1)
         (Meta (MetaConsAnon cname 0 nfields) a)) c where
-  verilogImpl' _ _ baseName = do
+  verilogImpl' _ _ bsType baseName = do
     let structName = baseName +++ "_t"
     whenNoDecl structName (stringOf pkg) do
       fields <- verilogFields' (prx :: a) False
-      emitDecl (stringOf pkg) $ VStruct structName fields
+      emitDecls (stringOf pkg) $ lst
+        (VComment bsType)
+        (VStruct structName fields)
 
 -- Tagged union case
 instance (TagNames a, VerilogSummands a) =>
     VerilogImpl' (Meta (MetaData name pkg ta nc) a) c where
-  verilogImpl' _ _ baseName = do
+  verilogImpl' _ _ bsType baseName = do
     let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
     let unionName = baseName +++ "_content_t"
     let structName = baseName +++ "_t"
@@ -373,6 +413,7 @@ instance (TagNames a, VerilogSummands a) =>
       fields <- verilogSummands (prx :: a) baseName (stringOf pkg) $ valueOf c
       emitDecls (stringOf pkg) $ lst
         (VUnion unionName fields)
+        (VComment bsType)
         (VStruct structName $ lst
           (VField (VTypeName enumName) "tag")
           (VField (VTypeName unionName) "content"))
@@ -506,6 +547,7 @@ writeVDecl file (VLocalParam name value) = do
   hPutStrLn file $ "localparam " +++ name +++ " = " +++
     integerToString (log2 $ value + 1) +++ "'d" +++
     integerToString value +++ ";"
+writeVDecl file (VComment comment) = hPutStrLn file $ "// " +++ comment
 
 writeVField :: Handle -> VField -> Module Empty
 writeVField file (VField ty name) =

--- a/Libraries/VerilogRepr/VerilogRepr.bs
+++ b/Libraries/VerilogRepr/VerilogRepr.bs
@@ -229,6 +229,8 @@ makeLogicArray n signed = VPackedArray n $
 struct TypeInfo =
   -- The Bluespec type expression
   bsType :: String
+  -- The package in which the Bluespec type was defined
+  bsPackage :: String
   -- The size of the type in bits
   size :: Integer
   -- The SystemVerilog base type (e.g. "logic" or "some_struct_t")
@@ -240,6 +242,8 @@ struct TypeInfo =
   sort :: TypeSort
   -- Whether this type is signed, if the type is a primitive
   signed :: Maybe Bool
+  -- The Bluespec type of the elements, if the type is a vector
+  bsElemType :: Maybe String
   -- The type's fields, if it's a struct
   fields :: Maybe (List FieldInfo)
   -- The values of the type's enum tags, if the type is an enum or tagged union
@@ -329,6 +333,7 @@ emitDecl pkg newDecl = RenderVerilog $ \ names decls infos ->
   in ((), map checkName (vDeclNames newDecl) `append` names,
       decls <: newDecl, infos)
 
+-- Add a list of Verilog declarations to the result.
 emitDecls :: String -> List VDecl -> RenderVerilog ()
 emitDecls pkg = mapM_ (emitDecl pkg)
 
@@ -337,16 +342,17 @@ emitTypeInfo :: TypeInfo -> RenderVerilog ()
 emitTypeInfo info = RenderVerilog $ \ names decls infos ->
   ((), names, decls, info :> infos)
 
--- Add a TypeInfo to the result, if it has not yet been added.
-emitTypeInfoIfNeeded :: TypeInfo -> RenderVerilog ()
-emitTypeInfoIfNeeded info = RenderVerilog $ \ names decls infos ->
-  if any (bsTypeEquals info.bsType) infos
+-- Control flow combinator - emit some declarations only if a type has not
+-- already been instantiated.
+whenNoTypeInfo :: String -> RenderVerilog () -> RenderVerilog ()
+whenNoTypeInfo bsType (RenderVerilog f) = RenderVerilog $ \ names decls infos ->
+  if any (bsTypeEquals bsType) infos
   then ((), names, decls, infos)
-  else ((), names, decls, info :> infos)
+  else f names decls infos
 
--- Control flow combinator - emit some declarations only if they a name has not
--- already been instantiated. Errors if the name conflicts with a type with the
--- same name but from a different package.
+-- Control flow combinator - emit some declarations only if a Verilog name has
+-- not yet been defined. Errors if the name conflicts with a name instantiated
+-- from a type in a different package.
 whenNoDecl :: String -> String -> RenderVerilog () -> RenderVerilog ()
 whenNoDecl name pkg (RenderVerilog f) = RenderVerilog $ \ names decls infos ->
   case lookup name names of
@@ -359,16 +365,19 @@ whenNoDecl name pkg (RenderVerilog f) = RenderVerilog $ \ names decls infos ->
 
 -- Helper function for defining verilogType for a type that maps to a logic
 -- (or logic array) type in Verilog.
--- The arguments are whether the type is signed, and a proxy for the type.
+-- The argument is a proxy for the type.
 mkPrimType :: (VerilogRepr a, TypeId a, Bits a n) => a -> RenderVerilog VType
 mkPrimType proxy = do
-  emitTypeInfoIfNeeded $ TypeInfo {
-    bsType = bsType proxy;
+  let bsTypeStr = bsType proxy
+  whenNoTypeInfo bsTypeStr $ emitTypeInfo $ TypeInfo {
+    bsType = bsTypeStr;
+    bsPackage = "Prelude";
     size = valueOf n;
     baseType = "logic";
     arraySize = if valueOf n == 1 then nil else lst $ valueOf n;
     sort = Primitive;
     signed = Just False;
+    bsElemType = Nothing;
     fields = Nothing;
     enumValues = Nothing;
     tagSize = Nothing;
@@ -379,6 +388,43 @@ mkPrimType proxy = do
   }
   return $ makeLogicArray (valueOf n) False
 
+-- Helper function for defining verilogType for a type that maps to a custom
+-- enum type in Verilog.
+-- The arguments are the package name, a list of enum constants, and a proxy
+-- for the type.
+mkEnumType :: (TypeId a) => String -> List String -> a -> RenderVerilog VType
+mkEnumType pkg tags proxy = do
+  let bsTypeStr = bsType proxy
+  let baseName = verilogTypeId proxy
+  let enumName = baseName +++ "_t"
+  let width = log2 $ length tags
+  whenNoTypeInfo bsTypeStr $ do
+    emitDecls pkg $ lst
+      (VComment bsTypeStr)
+      (VLocalParam (toUpperSnakeCase baseName +++ "_WIDTH")
+        (log2 $ width + 1) width)
+      (VLocalParam ("NUM_" +++ toUpperSnakeCase baseName)
+        (log2 $ length tags + 1) $ length tags)
+      (VEnum enumName width tags)
+    emitTypeInfo $ TypeInfo {
+      bsType = bsTypeStr;
+      bsPackage = pkg;
+      size = width;
+      baseType = enumName;
+      arraySize = nil;
+      sort = Enum;
+      signed = Nothing;
+      bsElemType = Nothing;
+      fields = Nothing;
+      enumValues = Just $ zip tags $ upto 0 $ length tags;
+      tagSize = Nothing;
+      contentSize = Nothing;
+      tagEnumName = Nothing;
+      unionName = Nothing;
+      alts = Nothing;
+    }
+  return $ VTypeName enumName
+
 -- Helper function for defining verilogType for a type that maps to a struct
 -- type in Verilog, that simply wraps the flattened fields determined by
 -- verilogFields.
@@ -387,20 +433,26 @@ mkPrimType proxy = do
 mkStructType :: (VerilogRepr a, TypeId a, Bits a n) =>
   String -> String -> a -> RenderVerilog VType
 mkStructType pkg base proxy = do
+  let bsTypeStr = bsType proxy
   let structName = verilogTypeId proxy +++ "_t"
-  whenNoDecl structName pkg do
+  whenNoTypeInfo bsTypeStr $ do
     fieldsAndInfos <- verilogFields (prx :: a) base
     let (fields, infos) = unzip fieldsAndInfos
-    emitDecls pkg $ lst
-      (VComment $ bsType proxy)
+    -- It's safe to put generating the struct declaration here under the
+    -- whenNoTypeDecl, because the same fully-instantiated Bluespec type will
+    -- never produce more than one different Verilog type.
+    whenNoDecl structName pkg $ emitDecls pkg $ lst
+      (VComment bsTypeStr)
       (VStruct structName fields)
     emitTypeInfo $ TypeInfo {
-      bsType = bsType proxy;
+      bsType = bsTypeStr;
+      bsPackage = pkg;
       size = valueOf n;
       baseType = structName;
       arraySize = nil;
       sort = Struct;
       signed = Nothing;
+      bsElemType = Nothing;
       fields = Just infos;
       enumValues = Nothing;
       tagSize = Nothing;
@@ -461,18 +513,21 @@ instance VerilogRepr (UInt n) where
 
 instance VerilogRepr (Int n) where
   verilogType proxy = do
+    let bsTypeStr = bsType proxy
     let typedefName = "int" +++ integerToString (valueOf n) +++ "_t"
-    whenNoDecl typedefName "Prelude" do
+    whenNoTypeInfo bsTypeStr do
       emitDecls "Prelude" $ lst
         (VComment $ "Int " +++ integerToString (valueOf n))
         (VTypedef typedefName $ makeLogicArray (valueOf n) True)
       emitTypeInfo $ TypeInfo {
-        bsType = bsType proxy;
+        bsType = bsTypeStr;
+        bsPackage = "Prelude";
         size = valueOf n;
         baseType = typedefName;
         arraySize = nil;
         sort = Primitive;
         signed = Just True;
+        bsElemType = Nothing;
         fields = Nothing;
         enumValues = Nothing;
         tagSize = Nothing;
@@ -494,13 +549,16 @@ instance (TypeId a, VerilogRepr a, Bits a nb) =>
     VerilogRepr (Vector.Vector n a) where
   verilogType proxy = do
     itemType <- verilogType (prx :: a)
-    emitTypeInfoIfNeeded $ TypeInfo {
-      bsType = bsType proxy;
+    let bsTypeStr = bsType proxy
+    whenNoTypeInfo bsTypeStr $ emitTypeInfo $ TypeInfo {
+      bsType = bsTypeStr;
+      bsPackage = "Vector";
       size = valueOf n * valueOf nb;
       baseType = lppVType itemType;
       arraySize = valueOf n :> vTypeArraySizes itemType;
       sort = Vector;
       signed = Nothing;
+      bsElemType = Just $ bsType (prx :: a);
       fields = Nothing;
       enumValues = Nothing;
       tagSize = Nothing;
@@ -565,30 +623,33 @@ class VerilogImpl a c where
 
 -- Pure enum case
 instance (TagNames a) => VerilogImpl (Meta (MetaData name pkg ta nc) a) 0 where
-  verilogImpl _ _ bsType baseName = if valueOf nc <= 1 then return () else do
-    -- Generate the same "tag" enum as the tagged-union case and typedef it,
-    -- since there might be other instantiations that are not a pure enum,
-    -- and want to use the same tag names.
-    let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
-    let typedefName = baseName +++ "_t"
-    let enumTagNames = tagNames (prx :: a) $ stringOf name
-    whenNoDecl enumName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
-      (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH")
-        (log2 $ log2 (valueOf nc) + 1) (log2 $ valueOf nc))
-      (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name))
-        (log2 $ valueOf nc + 1) $ valueOf nc)
-      (VEnum enumName (log2 $ valueOf nc) enumTagNames)
-    whenNoDecl typedefName (stringOf pkg) do
+  verilogImpl _ _ bsType baseName =
+    if valueOf nc <= 1 then return ()
+    else whenNoTypeInfo bsType do
+      -- Generate the same "tag" enum as the tagged-union case and typedef it,
+      -- since there might be other instantiations that are not a pure enum,
+      -- and want to use the same tag names.
+      let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
+      let typedefName = baseName +++ "_t"
+      let enumTagNames = tagNames (prx :: a) $ stringOf name
+      whenNoDecl enumName (stringOf pkg) $ emitDecls (stringOf pkg) $ lst
+        (VLocalParam (toUpperSnakeCase (stringOf name) +++ "_TAG_WIDTH")
+          (log2 $ log2 (valueOf nc) + 1) (log2 $ valueOf nc))
+        (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name))
+          (log2 $ valueOf nc + 1) $ valueOf nc)
+        (VEnum enumName (log2 $ valueOf nc) enumTagNames)
       emitDecls (stringOf pkg) $ lst
         (VComment bsType)
         (VTypedef typedefName $ VTypeName enumName)
       emitTypeInfo $ TypeInfo {
         bsType = bsType;
+        bsPackage = stringOf pkg;
         size = log2 $ valueOf nc;
         baseType = typedefName;
         arraySize = nil;
         sort = Enum;
         signed = Nothing;
+        bsElemType = Nothing;
         fields = Nothing;
         enumValues = Just $ zip enumTagNames $ 0 `upto` (valueOf nc - 1);
         tagSize = Nothing;
@@ -616,62 +677,64 @@ instance (VerilogFields a) =>
     VerilogImpl'
       (Meta (MetaData name pkg ta 1)
         (Meta (MetaConsNamed cname 0 nfields) a)) c where
-  verilogImpl' _ _ bsType baseName = do
+  verilogImpl' _ _ bsType baseName = whenNoTypeInfo bsType do
     let structName = baseName +++ "_t"
-    whenNoDecl structName (stringOf pkg) do
-      fieldsAndInfos <- verilogFields' (prx :: a) True
-      let (fields, infos) = unzip fieldsAndInfos
-      emitDecls (stringOf pkg) $ lst
-        (VComment bsType)
-        (VStruct structName fields)
-      emitTypeInfo $ TypeInfo {
-        bsType = bsType;
-        size = valueOf c;
-        baseType = structName;
-        arraySize = nil;
-        sort = Struct;
-        signed = Nothing;
-        fields = Just infos;
-        enumValues = Nothing;
-        tagSize = Nothing;
-        contentSize = Nothing;
-        tagEnumName = Nothing;
-        unionName = Nothing;
-        alts = Nothing;
-      }
+    fieldsAndInfos <- verilogFields' (prx :: a) True
+    let (fields, infos) = unzip fieldsAndInfos
+    emitDecls (stringOf pkg) $ lst
+      (VComment bsType)
+      (VStruct structName fields)
+    emitTypeInfo $ TypeInfo {
+      bsType = bsType;
+      bsPackage = stringOf pkg;
+      size = valueOf c;
+      baseType = structName;
+      arraySize = nil;
+      sort = Struct;
+      signed = Nothing;
+      bsElemType = Nothing;
+      fields = Just infos;
+      enumValues = Nothing;
+      tagSize = Nothing;
+      contentSize = Nothing;
+      tagEnumName = Nothing;
+      unionName = Nothing;
+      alts = Nothing;
+    }
 
 instance (VerilogFields a) =>
     VerilogImpl'
       (Meta (MetaData name pkg ta 1)
         (Meta (MetaConsAnon cname 0 nfields) a)) c where
-  verilogImpl' _ _ bsType baseName = do
+  verilogImpl' _ _ bsType baseName = whenNoTypeInfo bsType do
     let structName = baseName +++ "_t"
-    whenNoDecl structName (stringOf pkg) do
-      fieldsAndInfos <- verilogFields' (prx :: a) False
-      let (fields, infos) = unzip fieldsAndInfos
-      emitDecls (stringOf pkg) $ lst
-        (VComment bsType)
-        (VStruct structName fields)
-      emitTypeInfo $ TypeInfo {
-        bsType = bsType;
-        size = valueOf c;
-        baseType = structName;
-        arraySize = nil;
-        sort = Struct;
-        signed = Nothing;
-        fields = Just infos;
-        enumValues = Nothing;
-        tagSize = Nothing;
-        contentSize = Nothing;
-        tagEnumName = Nothing;
-        unionName = Nothing;
-        alts = Nothing;
-      }
+    fieldsAndInfos <- verilogFields' (prx :: a) False
+    let (fields, infos) = unzip fieldsAndInfos
+    emitDecls (stringOf pkg) $ lst
+      (VComment bsType)
+      (VStruct structName fields)
+    emitTypeInfo $ TypeInfo {
+      bsType = bsType;
+      bsPackage = stringOf pkg;
+      size = valueOf c;
+      baseType = structName;
+      arraySize = nil;
+      sort = Struct;
+      signed = Nothing;
+      bsElemType = Nothing;
+      fields = Just infos;
+      enumValues = Nothing;
+      tagSize = Nothing;
+      contentSize = Nothing;
+      tagEnumName = Nothing;
+      unionName = Nothing;
+      alts = Nothing;
+    }
 
 -- Tagged union case
 instance (TagNames a, VerilogSummands a) =>
     VerilogImpl' (Meta (MetaData name pkg ta nc) a) c where
-  verilogImpl' _ _ bsType baseName = do
+  verilogImpl' _ _ bsType baseName = whenNoTypeInfo bsType do
     let enumName = toLowerSnakeCase (stringOf name) +++ "_tag_t"
     let enumTagNames = tagNames (prx :: a) $ stringOf name
     let unionName = baseName +++ "_content_t"
@@ -682,31 +745,32 @@ instance (TagNames a, VerilogSummands a) =>
       (VLocalParam ("NUM_" +++ toUpperSnakeCase (stringOf name))
         (log2 $ valueOf nc + 1) $ valueOf nc)
       (VEnum enumName (log2 $ valueOf nc) enumTagNames)
-    whenNoDecl structName (stringOf pkg) do
-      fieldsAndInfos <- verilogSummands
-        (prx :: a) (stringOf name) baseName (stringOf pkg) $ valueOf c
-      let (fields, infos) = unzip fieldsAndInfos
-      emitDecls (stringOf pkg) $ lst
-        (VUnion unionName fields)
-        (VComment bsType)
-        (VStruct structName $ lst
-          (VField (VTypeName enumName) "tag")
-          (VField (VTypeName unionName) "content"))
-      emitTypeInfo $ TypeInfo {
-        bsType = bsType;
-        size = log2 (valueOf nc) + valueOf c;
-        baseType = structName;
-        arraySize = nil;
-        sort = TaggedUnion;
-        signed = Nothing;
-        fields = Nothing;
-        enumValues = Just $ zip enumTagNames $ 0 `upto` (valueOf nc - 1);
-        tagSize = Just $ log2 $ valueOf nc;
-        contentSize = Just $ valueOf c;
-        tagEnumName = Just enumName;
-        unionName = Just unionName;
-        alts = Just infos;
-      }
+    fieldsAndInfos <- verilogSummands
+      (prx :: a) (stringOf name) baseName (stringOf pkg) $ valueOf c
+    let (fields, infos) = unzip fieldsAndInfos
+    emitDecls (stringOf pkg) $ lst
+      (VUnion unionName fields)
+      (VComment bsType)
+      (VStruct structName $ lst
+        (VField (VTypeName enumName) "tag")
+        (VField (VTypeName unionName) "content"))
+    emitTypeInfo $ TypeInfo {
+      bsType = bsType;
+      bsPackage = stringOf pkg;
+      size = log2 (valueOf nc) + valueOf c;
+      baseType = structName;
+      arraySize = nil;
+      sort = TaggedUnion;
+      signed = Nothing;
+      bsElemType = Nothing;
+      fields = Nothing;
+      enumValues = Just $ zip enumTagNames $ 0 `upto` (valueOf nc - 1);
+      tagSize = Just $ log2 $ valueOf nc;
+      contentSize = Just $ valueOf c;
+      tagEnumName = Just enumName;
+      unionName = Just unionName;
+      alts = Just infos;
+    }
 
 -- Generate the union fields for summands in a tagged union.
 class VerilogSummands a where

--- a/testing/bsc.contrib/VerilogRepr/Chess.bs
+++ b/testing/bsc.contrib/VerilogRepr/Chess.bs
@@ -1,0 +1,113 @@
+package Chess where
+
+import Vector
+import VerilogRepr
+
+-- From https://github.com/krame505/hardware-chess
+
+data PieceKind
+  = Pawn
+  | Knight
+  | Bishop
+  | Rook
+  | Queen
+  | King
+ deriving (Eq, Bits)
+
+data Color = White | Black
+ deriving (Eq, Bits)
+
+struct Piece =
+  color :: Color
+  kind :: PieceKind
+ deriving (Eq, Bits)
+
+type Board = Vector 8 (Vector 8 (Maybe Piece))
+
+struct Position =
+  rank :: UInt 3
+  file :: UInt 3
+ deriving (Eq, Bits)
+
+struct PlayerHistory =
+  pawnMoved2 :: Maybe (UInt 3)
+  kingMoved :: Bool
+  kRookMoved :: Bool
+  qRookMoved :: Bool
+  castled :: Bool
+ deriving (Eq, Bits)
+
+struct State =
+  turn :: Color
+  board :: Board
+  whiteHist :: PlayerHistory
+  blackHist :: PlayerHistory
+  lastProgressMove :: UInt 6
+ deriving (Eq, Bits)
+
+data Move
+  = Move { from :: Position; to :: Position }
+  | EnPassant { from :: Position; to :: Position }
+  | Promote { kind :: PieceKind; from :: Position; to :: Position }
+  | Castle {kingSide :: Bool}
+ deriving (Eq, Bits)
+
+data Outcome = NoOutcome | Check | CheckMate | Draw
+  deriving (Bits)
+
+type Score maxScore = Int (TAdd 1 (TLog maxScore))
+type RequestId = UInt 8
+
+struct SearchQuery config maxScore maxDepth =
+  rid :: RequestId
+  state :: State
+  depth :: UInt (TLog maxDepth)
+  getMoves :: Bool
+  alpha :: Maybe (Score maxScore)
+  beta :: Maybe (Score maxScore)
+  conf :: config
+ deriving (Bits)
+
+struct SearchResult maxScore maxDepth =
+  rid :: RequestId
+  outcome :: Outcome
+  bestMove :: Maybe Move
+  forcedOutcome :: Bool  -- Can either player force a win
+  score :: (Score maxScore)
+  depth :: UInt (TLog maxDepth)
+ deriving (Bits)
+
+struct Config weight =
+  materialValue :: weight
+  centerControlValue :: weight
+  extendedCenterControlValue :: weight
+  castleValue :: weight
+  pawnStructureValue :: weight
+ deriving (Bits)
+
+type MaxScore = 500
+type MaxWeight = 4
+type MaxDepth = 16
+
+type DefaultSearchQuery = SearchQuery (Config (UInt (TLog MaxWeight))) MaxScore MaxDepth
+type DefaultSearchResult = SearchResult MaxScore MaxDepth
+
+genFileName :: String
+genFileName = "chess.svh"
+
+type SVTypes = (DefaultSearchQuery, DefaultSearchResult)
+
+renderAll :: RenderVerilog ()
+renderAll = do
+  emitDecl "Chess" $ VLocalParam "MAX_SCORE" $ valueOf MaxScore
+  emitDecl "Chess" $ VLocalParam "MAX_WEIGHT" $ valueOf MaxWeight
+  emitDecl "Chess" $ VLocalParam "MAX_DEPTH" $ valueOf MaxDepth
+  verilogImpls (prx :: SVTypes)
+
+{-# synthesize main #-}
+main :: Module Empty
+main = writeVerilogFile
+  genFileName
+  "package chess;\n\n"
+  "endpackage"
+  renderAll

--- a/testing/bsc.contrib/VerilogRepr/Chess.bs
+++ b/testing/bsc.contrib/VerilogRepr/Chess.bs
@@ -55,7 +55,7 @@ data Move
 data Outcome = NoOutcome | Check | CheckMate | Draw
   deriving (Bits)
 
-type Score maxScore = Int (TAdd 1 (TLog maxScore))
+type Score maxScore = Int (TLog (TAdd 1 maxScore))
 type RequestId = UInt 8
 
 struct SearchQuery config maxScore maxDepth =
@@ -92,22 +92,25 @@ type MaxDepth = 16
 type DefaultSearchQuery = SearchQuery (Config (UInt (TLog MaxWeight))) MaxScore MaxDepth
 type DefaultSearchResult = SearchResult MaxScore MaxDepth
 
-genFileName :: String
-genFileName = "chess.svh"
-
 type SVTypes = (DefaultSearchQuery, DefaultSearchResult)
 
 renderAll :: RenderVerilog ()
 renderAll = do
-  emitDecl "Chess" $ VLocalParam "MAX_SCORE" $ valueOf MaxScore
-  emitDecl "Chess" $ VLocalParam "MAX_WEIGHT" $ valueOf MaxWeight
-  emitDecl "Chess" $ VLocalParam "MAX_DEPTH" $ valueOf MaxDepth
+  emitDecl "Chess" $ VLocalParam "MAX_SCORE" (log2 $ 1 + valueOf MaxScore) $ valueOf MaxScore
+  emitDecl "Chess" $ VLocalParam "MAX_WEIGHT" (log2 $ 1 + valueOf MaxWeight) $ valueOf MaxWeight
+  emitDecl "Chess" $ VLocalParam "MAX_DEPTH" (log2 $ 1 + valueOf MaxDepth) $ valueOf MaxDepth
   verilogImpls (prx :: SVTypes)
+
+svFileName :: String
+svFileName = "chess.svh"
+
+jsonFileName :: String
+jsonFileName = "chess_types.json"
 
 {-# synthesize main #-}
 main :: Module Empty
-main = writeVerilogFile
-  genFileName
+main = writeVerilogAndJsonFile
+  svFileName jsonFileName
   "package chess;\n\n"
   "endpackage"
   renderAll

--- a/testing/bsc.contrib/VerilogRepr/Makefile
+++ b/testing/bsc.contrib/VerilogRepr/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testing/bsc.contrib/VerilogRepr/chess.svh.expected
+++ b/testing/bsc.contrib/VerilogRepr/chess.svh.expected
@@ -59,6 +59,9 @@ typedef struct packed {
   logic [5:0] last_progress_move;
 } state_t;
 
+// Int 9
+typedef logic signed [8:0] int9_t;
+
 // Config (UInt 2)
 typedef struct packed {
   logic [1:0] material_value;
@@ -75,9 +78,9 @@ typedef struct packed {
   logic [3:0] depth;
   logic get_moves;
   logic has_alpha;
-  logic signed [9:0] alpha;
+  int9_t alpha;
   logic has_beta;
-  logic signed [9:0] beta;
+  int9_t beta;
   config_uint2_t conf;
 } search_query_config_uint2_500_16_t;
 
@@ -151,7 +154,7 @@ typedef struct packed {
   logic has_best_move;
   move_t best_move;
   logic forced_outcome;
-  logic signed [9:0] score;
+  int9_t score;
   logic [3:0] depth;
 } search_result_500_16_t;
 

--- a/testing/bsc.contrib/VerilogRepr/chess.svh.expected
+++ b/testing/bsc.contrib/VerilogRepr/chess.svh.expected
@@ -1,0 +1,158 @@
+package chess;
+
+
+localparam MAX_SCORE = 9'd500;
+localparam MAX_WEIGHT = 3'd4;
+localparam MAX_DEPTH = 5'd16;
+localparam COLOR_TAG_WIDTH = 1'd1;
+localparam NUM_COLOR = 2'd2;
+typedef enum logic [0:0] {
+  COLOR_WHITE = 1'd0,
+  COLOR_BLACK = 1'd1
+} color_tag_t;
+
+// Color
+typedef color_tag_t color_t;
+
+localparam PIECE_KIND_TAG_WIDTH = 2'd3;
+localparam NUM_PIECE_KIND = 3'd6;
+typedef enum logic [2:0] {
+  PIECE_KIND_PAWN = 3'd0,
+  PIECE_KIND_KNIGHT = 3'd1,
+  PIECE_KIND_BISHOP = 3'd2,
+  PIECE_KIND_ROOK = 3'd3,
+  PIECE_KIND_QUEEN = 3'd4,
+  PIECE_KIND_KING = 3'd5
+} piece_kind_tag_t;
+
+// PieceKind
+typedef piece_kind_tag_t piece_kind_t;
+
+// Piece
+typedef struct packed {
+  color_t color;
+  piece_kind_t kind;
+} piece_t;
+
+// Maybe Piece
+typedef struct packed {
+  logic has_value;
+  piece_t value;
+} option_piece_t;
+
+// PlayerHistory
+typedef struct packed {
+  logic has_pawn_moved2;
+  logic [2:0] pawn_moved2;
+  logic king_moved;
+  logic k_rook_moved;
+  logic q_rook_moved;
+  logic castled;
+} player_history_t;
+
+// State
+typedef struct packed {
+  color_t turn;
+  option_piece_t [7:0][7:0] board;
+  player_history_t white_hist;
+  player_history_t black_hist;
+  logic [5:0] last_progress_move;
+} state_t;
+
+// Config (UInt 2)
+typedef struct packed {
+  logic [1:0] material_value;
+  logic [1:0] center_control_value;
+  logic [1:0] extended_center_control_value;
+  logic [1:0] castle_value;
+  logic [1:0] pawn_structure_value;
+} config_uint2_t;
+
+// SearchQuery (Config (UInt 2)) 500 16
+typedef struct packed {
+  logic [7:0] rid;
+  state_t state;
+  logic [3:0] depth;
+  logic get_moves;
+  logic has_alpha;
+  logic signed [9:0] alpha;
+  logic has_beta;
+  logic signed [9:0] beta;
+  config_uint2_t conf;
+} search_query_config_uint2_500_16_t;
+
+localparam OUTCOME_TAG_WIDTH = 2'd2;
+localparam NUM_OUTCOME = 3'd4;
+typedef enum logic [1:0] {
+  OUTCOME_NO_OUTCOME = 2'd0,
+  OUTCOME_CHECK = 2'd1,
+  OUTCOME_CHECK_MATE = 2'd2,
+  OUTCOME_DRAW = 2'd3
+} outcome_tag_t;
+
+// Outcome
+typedef outcome_tag_t outcome_t;
+
+localparam MOVE_TAG_WIDTH = 2'd2;
+localparam NUM_MOVE = 3'd4;
+typedef enum logic [1:0] {
+  MOVE_MOVE = 2'd0,
+  MOVE_EN_PASSANT = 2'd1,
+  MOVE_PROMOTE = 2'd2,
+  MOVE_CASTLE = 2'd3
+} move_tag_t;
+
+// Position
+typedef struct packed {
+  logic [2:0] rank;
+  logic [2:0] file;
+} position_t;
+
+typedef struct packed {
+  logic [2:0] pad;
+  position_t from;
+  position_t to;
+} move_move_t;
+
+typedef struct packed {
+  logic [2:0] pad;
+  position_t from;
+  position_t to;
+} move_en_passant_t;
+
+typedef struct packed {
+  piece_kind_t kind;
+  position_t from;
+  position_t to;
+} move_promote_t;
+
+typedef struct packed {
+  logic [13:0] pad;
+  logic king_side;
+} move_castle_t;
+
+typedef union packed {
+  move_move_t move;
+  move_en_passant_t en_passant;
+  move_promote_t promote;
+  move_castle_t castle;
+} move_content_t;
+
+// Move
+typedef struct packed {
+  move_tag_t tag;
+  move_content_t content;
+} move_t;
+
+// SearchResult 500 16
+typedef struct packed {
+  logic [7:0] rid;
+  outcome_t outcome;
+  logic has_best_move;
+  move_t best_move;
+  logic forced_outcome;
+  logic signed [9:0] score;
+  logic [3:0] depth;
+} search_result_500_16_t;
+
+endpackage

--- a/testing/bsc.contrib/VerilogRepr/chess_types.json.expected
+++ b/testing/bsc.contrib/VerilogRepr/chess_types.json.expected
@@ -1,6 +1,7 @@
 [
   {
     "bsType": "SearchResult 500 16",
+    "bsPackage": "Chess",
     "size": 42,
     "baseType": "search_result_500_16_t",
     "arraySize": [],
@@ -63,6 +64,7 @@
   },
   {
     "bsType": "Move",
+    "bsPackage": "Chess",
     "size": 17,
     "baseType": "move_t",
     "arraySize": [],
@@ -174,6 +176,7 @@
   },
   {
     "bsType": "Position",
+    "bsPackage": "Chess",
     "size": 6,
     "baseType": "position_t",
     "arraySize": [],
@@ -201,6 +204,7 @@
   },
   {
     "bsType": "Outcome",
+    "bsPackage": "Chess",
     "size": 2,
     "baseType": "outcome_t",
     "arraySize": [],
@@ -214,6 +218,7 @@
   },
   {
     "bsType": "SearchQuery (Config (UInt 2)) 500 16",
+    "bsPackage": "Chess",
     "size": 386,
     "baseType": "search_query_config_uint2_500_16_t",
     "arraySize": [],
@@ -290,6 +295,7 @@
   },
   {
     "bsType": "Config (UInt 2)",
+    "bsPackage": "Chess",
     "size": 10,
     "baseType": "config_uint2_t",
     "arraySize": [],
@@ -344,6 +350,7 @@
   },
   {
     "bsType": "UInt 2",
+    "bsPackage": "Prelude",
     "size": 2,
     "baseType": "logic",
     "arraySize": [
@@ -354,6 +361,7 @@
   },
   {
     "bsType": "Int 9",
+    "bsPackage": "Prelude",
     "size": 9,
     "baseType": "int9_t",
     "arraySize": [],
@@ -362,6 +370,7 @@
   },
   {
     "bsType": "UInt 4",
+    "bsPackage": "Prelude",
     "size": 4,
     "baseType": "logic",
     "arraySize": [
@@ -372,6 +381,7 @@
   },
   {
     "bsType": "State",
+    "bsPackage": "Chess",
     "size": 343,
     "baseType": "state_t",
     "arraySize": [],
@@ -421,6 +431,7 @@
   },
   {
     "bsType": "UInt 6",
+    "bsPackage": "Prelude",
     "size": 6,
     "baseType": "logic",
     "arraySize": [
@@ -431,6 +442,7 @@
   },
   {
     "bsType": "PlayerHistory",
+    "bsPackage": "Chess",
     "size": 8,
     "baseType": "player_history_t",
     "arraySize": [],
@@ -484,6 +496,7 @@
   },
   {
     "bsType": "UInt 3",
+    "bsPackage": "Prelude",
     "size": 3,
     "baseType": "logic",
     "arraySize": [
@@ -494,25 +507,30 @@
   },
   {
     "bsType": "Vector 8 (Vector 8 (Maybe Piece))",
+    "bsPackage": "Vector",
     "size": 320,
     "baseType": "option_piece_t",
     "arraySize": [
       8,
       8
     ],
-    "sort": "Vector"
+    "sort": "Vector",
+    "bsElemType": "Vector 8 (Maybe Piece)"
   },
   {
     "bsType": "Vector 8 (Maybe Piece)",
+    "bsPackage": "Vector",
     "size": 40,
     "baseType": "option_piece_t",
     "arraySize": [
       8
     ],
-    "sort": "Vector"
+    "sort": "Vector",
+    "bsElemType": "Maybe Piece"
   },
   {
     "bsType": "Maybe Piece",
+    "bsPackage": "Prelude",
     "size": 5,
     "baseType": "option_piece_t",
     "arraySize": [],
@@ -536,6 +554,7 @@
   },
   {
     "bsType": "Piece",
+    "bsPackage": "Chess",
     "size": 4,
     "baseType": "piece_t",
     "arraySize": [],
@@ -559,6 +578,7 @@
   },
   {
     "bsType": "PieceKind",
+    "bsPackage": "Chess",
     "size": 3,
     "baseType": "piece_kind_t",
     "arraySize": [],
@@ -574,6 +594,7 @@
   },
   {
     "bsType": "Bool",
+    "bsPackage": "Prelude",
     "size": 1,
     "baseType": "logic",
     "arraySize": [],
@@ -582,6 +603,7 @@
   },
   {
     "bsType": "Color",
+    "bsPackage": "Chess",
     "size": 1,
     "baseType": "color_t",
     "arraySize": [],
@@ -593,6 +615,7 @@
   },
   {
     "bsType": "UInt 8",
+    "bsPackage": "Prelude",
     "size": 8,
     "baseType": "logic",
     "arraySize": [

--- a/testing/bsc.contrib/VerilogRepr/chess_types.json.expected
+++ b/testing/bsc.contrib/VerilogRepr/chess_types.json.expected
@@ -1,0 +1,604 @@
+[
+  {
+    "bsType": "SearchResult 500 16",
+    "size": 42,
+    "baseType": "search_result_500_16_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "rid",
+        "size": 8,
+        "bsType": "UInt 8",
+        "baseType": "logic",
+        "arraySize": [
+          8
+        ]
+      },
+      {
+        "name": "outcome",
+        "size": 2,
+        "bsType": "Outcome",
+        "baseType": "outcome_t",
+        "arraySize": []
+      },
+      {
+        "name": "has_best_move",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "best_move",
+        "size": 17,
+        "bsType": "Move",
+        "baseType": "move_t",
+        "arraySize": []
+      },
+      {
+        "name": "forced_outcome",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "score",
+        "size": 9,
+        "bsType": "Int 9",
+        "baseType": "int9_t",
+        "arraySize": []
+      },
+      {
+        "name": "depth",
+        "size": 4,
+        "bsType": "UInt 4",
+        "baseType": "logic",
+        "arraySize": [
+          4
+        ]
+      }
+    ]
+  },
+  {
+    "bsType": "Move",
+    "size": 17,
+    "baseType": "move_t",
+    "arraySize": [],
+    "sort": "TaggedUnion",
+    "enumValues": {
+      "MOVE_MOVE": 0,
+      "MOVE_EN_PASSANT": 1,
+      "MOVE_PROMOTE": 2,
+      "MOVE_CASTLE": 3
+    },
+    "tagSize": 2,
+    "contentSize": 15,
+    "tagEnumName": "move_tag_t",
+    "unionName": "move_content_t",
+    "alts": [
+      {
+        "tagName": "MOVE_MOVE",
+        "fieldName": "move",
+        "structName": "move_move_t",
+        "padSize": 3,
+        "contentSize": 12,
+        "fields": [
+          {
+            "name": "from",
+            "size": 6,
+            "bsType": "Position",
+            "baseType": "position_t",
+            "arraySize": []
+          },
+          {
+            "name": "to",
+            "size": 6,
+            "bsType": "Position",
+            "baseType": "position_t",
+            "arraySize": []
+          }
+        ]
+      },
+      {
+        "tagName": "MOVE_EN_PASSANT",
+        "fieldName": "en_passant",
+        "structName": "move_en_passant_t",
+        "padSize": 3,
+        "contentSize": 12,
+        "fields": [
+          {
+            "name": "from",
+            "size": 6,
+            "bsType": "Position",
+            "baseType": "position_t",
+            "arraySize": []
+          },
+          {
+            "name": "to",
+            "size": 6,
+            "bsType": "Position",
+            "baseType": "position_t",
+            "arraySize": []
+          }
+        ]
+      },
+      {
+        "tagName": "MOVE_PROMOTE",
+        "fieldName": "promote",
+        "structName": "move_promote_t",
+        "padSize": 0,
+        "contentSize": 15,
+        "fields": [
+          {
+            "name": "kind",
+            "size": 3,
+            "bsType": "PieceKind",
+            "baseType": "piece_kind_t",
+            "arraySize": []
+          },
+          {
+            "name": "from",
+            "size": 6,
+            "bsType": "Position",
+            "baseType": "position_t",
+            "arraySize": []
+          },
+          {
+            "name": "to",
+            "size": 6,
+            "bsType": "Position",
+            "baseType": "position_t",
+            "arraySize": []
+          }
+        ]
+      },
+      {
+        "tagName": "MOVE_CASTLE",
+        "fieldName": "castle",
+        "structName": "move_castle_t",
+        "padSize": 14,
+        "contentSize": 1,
+        "fields": [
+          {
+            "name": "king_side",
+            "size": 1,
+            "bsType": "Bool",
+            "baseType": "logic",
+            "arraySize": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "bsType": "Position",
+    "size": 6,
+    "baseType": "position_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "rank",
+        "size": 3,
+        "bsType": "UInt 3",
+        "baseType": "logic",
+        "arraySize": [
+          3
+        ]
+      },
+      {
+        "name": "file",
+        "size": 3,
+        "bsType": "UInt 3",
+        "baseType": "logic",
+        "arraySize": [
+          3
+        ]
+      }
+    ]
+  },
+  {
+    "bsType": "Outcome",
+    "size": 2,
+    "baseType": "outcome_t",
+    "arraySize": [],
+    "sort": "Enum",
+    "enumValues": {
+      "OUTCOME_NO_OUTCOME": 0,
+      "OUTCOME_CHECK": 1,
+      "OUTCOME_CHECK_MATE": 2,
+      "OUTCOME_DRAW": 3
+    }
+  },
+  {
+    "bsType": "SearchQuery (Config (UInt 2)) 500 16",
+    "size": 386,
+    "baseType": "search_query_config_uint2_500_16_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "rid",
+        "size": 8,
+        "bsType": "UInt 8",
+        "baseType": "logic",
+        "arraySize": [
+          8
+        ]
+      },
+      {
+        "name": "state",
+        "size": 343,
+        "bsType": "State",
+        "baseType": "state_t",
+        "arraySize": []
+      },
+      {
+        "name": "depth",
+        "size": 4,
+        "bsType": "UInt 4",
+        "baseType": "logic",
+        "arraySize": [
+          4
+        ]
+      },
+      {
+        "name": "get_moves",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "has_alpha",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "alpha",
+        "size": 9,
+        "bsType": "Int 9",
+        "baseType": "int9_t",
+        "arraySize": []
+      },
+      {
+        "name": "has_beta",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "beta",
+        "size": 9,
+        "bsType": "Int 9",
+        "baseType": "int9_t",
+        "arraySize": []
+      },
+      {
+        "name": "conf",
+        "size": 10,
+        "bsType": "Config (UInt 2)",
+        "baseType": "config_uint2_t",
+        "arraySize": []
+      }
+    ]
+  },
+  {
+    "bsType": "Config (UInt 2)",
+    "size": 10,
+    "baseType": "config_uint2_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "material_value",
+        "size": 2,
+        "bsType": "UInt 2",
+        "baseType": "logic",
+        "arraySize": [
+          2
+        ]
+      },
+      {
+        "name": "center_control_value",
+        "size": 2,
+        "bsType": "UInt 2",
+        "baseType": "logic",
+        "arraySize": [
+          2
+        ]
+      },
+      {
+        "name": "extended_center_control_value",
+        "size": 2,
+        "bsType": "UInt 2",
+        "baseType": "logic",
+        "arraySize": [
+          2
+        ]
+      },
+      {
+        "name": "castle_value",
+        "size": 2,
+        "bsType": "UInt 2",
+        "baseType": "logic",
+        "arraySize": [
+          2
+        ]
+      },
+      {
+        "name": "pawn_structure_value",
+        "size": 2,
+        "bsType": "UInt 2",
+        "baseType": "logic",
+        "arraySize": [
+          2
+        ]
+      }
+    ]
+  },
+  {
+    "bsType": "UInt 2",
+    "size": 2,
+    "baseType": "logic",
+    "arraySize": [
+      2
+    ],
+    "sort": "Primitive",
+    "signed": false
+  },
+  {
+    "bsType": "Int 9",
+    "size": 9,
+    "baseType": "int9_t",
+    "arraySize": [],
+    "sort": "Primitive",
+    "signed": true
+  },
+  {
+    "bsType": "UInt 4",
+    "size": 4,
+    "baseType": "logic",
+    "arraySize": [
+      4
+    ],
+    "sort": "Primitive",
+    "signed": false
+  },
+  {
+    "bsType": "State",
+    "size": 343,
+    "baseType": "state_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "turn",
+        "size": 1,
+        "bsType": "Color",
+        "baseType": "color_t",
+        "arraySize": []
+      },
+      {
+        "name": "board",
+        "size": 320,
+        "bsType": "Vector 8 (Vector 8 (Maybe Piece))",
+        "baseType": "option_piece_t",
+        "arraySize": [
+          8,
+          8
+        ]
+      },
+      {
+        "name": "white_hist",
+        "size": 8,
+        "bsType": "PlayerHistory",
+        "baseType": "player_history_t",
+        "arraySize": []
+      },
+      {
+        "name": "black_hist",
+        "size": 8,
+        "bsType": "PlayerHistory",
+        "baseType": "player_history_t",
+        "arraySize": []
+      },
+      {
+        "name": "last_progress_move",
+        "size": 6,
+        "bsType": "UInt 6",
+        "baseType": "logic",
+        "arraySize": [
+          6
+        ]
+      }
+    ]
+  },
+  {
+    "bsType": "UInt 6",
+    "size": 6,
+    "baseType": "logic",
+    "arraySize": [
+      6
+    ],
+    "sort": "Primitive",
+    "signed": false
+  },
+  {
+    "bsType": "PlayerHistory",
+    "size": 8,
+    "baseType": "player_history_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "has_pawn_moved2",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "pawn_moved2",
+        "size": 3,
+        "bsType": "UInt 3",
+        "baseType": "logic",
+        "arraySize": [
+          3
+        ]
+      },
+      {
+        "name": "king_moved",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "k_rook_moved",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "q_rook_moved",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "castled",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      }
+    ]
+  },
+  {
+    "bsType": "UInt 3",
+    "size": 3,
+    "baseType": "logic",
+    "arraySize": [
+      3
+    ],
+    "sort": "Primitive",
+    "signed": false
+  },
+  {
+    "bsType": "Vector 8 (Vector 8 (Maybe Piece))",
+    "size": 320,
+    "baseType": "option_piece_t",
+    "arraySize": [
+      8,
+      8
+    ],
+    "sort": "Vector"
+  },
+  {
+    "bsType": "Vector 8 (Maybe Piece)",
+    "size": 40,
+    "baseType": "option_piece_t",
+    "arraySize": [
+      8
+    ],
+    "sort": "Vector"
+  },
+  {
+    "bsType": "Maybe Piece",
+    "size": 5,
+    "baseType": "option_piece_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "has_value",
+        "size": 1,
+        "bsType": "Bool",
+        "baseType": "logic",
+        "arraySize": []
+      },
+      {
+        "name": "value",
+        "size": 4,
+        "bsType": "Piece",
+        "baseType": "piece_t",
+        "arraySize": []
+      }
+    ]
+  },
+  {
+    "bsType": "Piece",
+    "size": 4,
+    "baseType": "piece_t",
+    "arraySize": [],
+    "sort": "Struct",
+    "fields": [
+      {
+        "name": "color",
+        "size": 1,
+        "bsType": "Color",
+        "baseType": "color_t",
+        "arraySize": []
+      },
+      {
+        "name": "kind",
+        "size": 3,
+        "bsType": "PieceKind",
+        "baseType": "piece_kind_t",
+        "arraySize": []
+      }
+    ]
+  },
+  {
+    "bsType": "PieceKind",
+    "size": 3,
+    "baseType": "piece_kind_t",
+    "arraySize": [],
+    "sort": "Enum",
+    "enumValues": {
+      "PIECE_KIND_PAWN": 0,
+      "PIECE_KIND_KNIGHT": 1,
+      "PIECE_KIND_BISHOP": 2,
+      "PIECE_KIND_ROOK": 3,
+      "PIECE_KIND_QUEEN": 4,
+      "PIECE_KIND_KING": 5
+    }
+  },
+  {
+    "bsType": "Bool",
+    "size": 1,
+    "baseType": "logic",
+    "arraySize": [],
+    "sort": "Primitive",
+    "signed": false
+  },
+  {
+    "bsType": "Color",
+    "size": 1,
+    "baseType": "color_t",
+    "arraySize": [],
+    "sort": "Enum",
+    "enumValues": {
+      "COLOR_WHITE": 0,
+      "COLOR_BLACK": 1
+    }
+  },
+  {
+    "bsType": "UInt 8",
+    "size": 8,
+    "baseType": "logic",
+    "arraySize": [
+      8
+    ],
+    "sort": "Primitive",
+    "signed": false
+  }
+]

--- a/testing/bsc.contrib/VerilogRepr/verilogrepr.exp
+++ b/testing/bsc.contrib/VerilogRepr/verilogrepr.exp
@@ -1,0 +1,14 @@
+# Include the boilerplate for bsc-contrib tests
+set here [file join [absolute $srcdir] $subdir]
+source $here/../contrib.tcl
+
+if { $contribtest } {
+
+    add_contrib_dirs_to_path { VerilogRepr }
+
+    compile_pass Chess.bs
+    compare_file chess.svh
+
+    restore_path
+
+}

--- a/testing/bsc.contrib/VerilogRepr/verilogrepr.exp
+++ b/testing/bsc.contrib/VerilogRepr/verilogrepr.exp
@@ -6,7 +6,7 @@ if { $contribtest } {
 
     add_contrib_dirs_to_path { VerilogRepr }
 
-    compile_pass Chess.bs
+    compile_verilog_pass Chess.bs
     compare_file chess.svh
 
     restore_path

--- a/testing/bsc.contrib/VerilogRepr/verilogrepr.exp
+++ b/testing/bsc.contrib/VerilogRepr/verilogrepr.exp
@@ -8,6 +8,7 @@ if { $contribtest } {
 
     compile_verilog_pass Chess.bs
     compare_file chess.svh
+    compare_file chess_types.json
 
     restore_path
 


### PR DESCRIPTION
This is a library I wrote for generating a library of equivalent packed struct/union definitions for types defined in Bluespec, at elaboration time using generics.  This can be useful if part of the design is written in Bluespec and part in SystemVerilog, to allow sharing common type definitions.

We have tested this library extensively and are using it in a real design, but the tests use parts of our RTL and we can't really open source them easily.  