### PR TITLE
Remove reliance on generalization of implicitly type let bindings

### DIFF
--- a/Libraries/AMBA_TLM3/TLM3/CB.bsv
+++ b/Libraries/AMBA_TLM3/TLM3/CB.bsv
@@ -74,7 +74,9 @@ endinterface
 module mkCompletionBuffer(CompletionBuffer#(ln, a, b))
    provisos (Bits#(a, sa), Bits#(b, sb), Add#(1, ln, ln1), FShow#(b));
 
-   let hi = fromInteger(valueOf(TExp#(ln)) - 1);
+   function t hi() provisos (Literal#(t));
+      return(fromInteger(valueOf(TExp#(ln)) - 1));
+   endfunction
 
    Reg#(Bool) initialized <- mkReg(False);
 


### PR DESCRIPTION
PR B-Lang-org/bsc#902 proposes to turn off generalization of implicit let bindings by default in BSC, and in that case the TLM3 library would fail to build.  It has a CompletionBuffer library (`CB.bsv`) that defines a variable-width index (`hi`) that needs an explicit generic type signature -- in the same way that PR 902 updates the CompletionBuffer library in BSC.  (I assume the one in TLM3 is different in some way, that TLM3 can't just use the one from the library?)